### PR TITLE
fix: correct {"intial"->"initial"} in Reflect call in memory.rs

### DIFF
--- a/src/backend/backend_web/memory.rs
+++ b/src/backend/backend_web/memory.rs
@@ -62,7 +62,7 @@ impl Memory {
 impl WasmMemory<Engine> for Memory {
     fn new(mut ctx: impl AsContextMut<Engine>, ty: crate::MemoryType) -> anyhow::Result<Self> {
         let desc = Object::new();
-        Reflect::set(&desc, &"intial".into(), &ty.initial.into()).unwrap();
+        Reflect::set(&desc, &"initial".into(), &ty.initial.into()).unwrap();
         if let Some(maximum) = ty.maximum {
             Reflect::set(&desc, &"maximum".into(), &maximum.into()).unwrap();
         }


### PR DESCRIPTION
Hi! Great work on this – I spotted this typo in a `Reflect::set` call while reading through to familiarize myself with the library and thought I'd send a PR. Tests ran and passed with `cargo test -F backend_wasmi` on an M2 Mac. Thanks for taking a look!