### PR TITLE
Sketch cleaned-up ExternRef API

### DIFF
--- a/src/backend/backend_wasmi.rs
+++ b/src/backend/backend_wasmi.rs
@@ -27,22 +27,19 @@ impl WasmEngine for wasmi::Engine {
 impl WasmExternRef<wasmi::Engine> for wasmi::ExternRef {
     fn new<T: 'static + Send + Sync>(
         mut ctx: impl AsContextMut<wasmi::Engine>,
-        object: Option<T>,
+        object: T,
     ) -> Self {
         Self::new::<T>(ctx.as_context_mut(), object)
     }
 
-    fn downcast<'a, T: 'static, S: 'a>(
-        &self,
-        store: <wasmi::Engine as WasmEngine>::StoreContext<'a, S>,
-    ) -> Result<Option<&'a T>> {
-        if let Some(data) = self.data(store) {
-            data.downcast_ref()
-                .ok_or_else(|| Error::msg("Incorrect extern ref type."))
-                .map(Some)
-        } else {
-            Ok(None)
-        }
+    fn downcast<'a, 's: 'a, T: 'static, S: 'a>(
+        &'a self,
+        store: <wasmi::Engine as WasmEngine>::StoreContext<'s, S>,
+    ) -> Result<&'a T> {
+        self.data(store)
+            .ok_or_else(|| Error::msg("externref None should be external"))?
+            .downcast_ref()
+            .ok_or_else(|| Error::msg("Incorrect extern ref type."))
     }
 }
 

--- a/src/backend/backend_wasmtime.rs
+++ b/src/backend/backend_wasmtime.rs
@@ -26,20 +26,19 @@ impl WasmEngine for wasmtime::Engine {
 impl WasmExternRef<wasmtime::Engine> for wasmtime::ExternRef {
     fn new<T: 'static + Send + Sync>(
         _: impl AsContextMut<wasmtime::Engine>,
-        object: Option<T>,
+        object: T,
     ) -> Self {
-        Self::new::<Option<T>>(object)
+        Self::new::<T>(object)
     }
 
-    fn downcast<'a, T: 'static, S: 'a>(
-        &self,
-        _: <wasmtime::Engine as WasmEngine>::StoreContext<'a, S>,
-    ) -> Result<Option<&'a T>> {
+    fn downcast<'a, 's: 'a, T: 'static, S: 's>(
+        &'a self,
+        _: <wasmtime::Engine as WasmEngine>::StoreContext<'s, S>,
+    ) -> Result<&'a T> {
         Ok(self
             .data()
-            .downcast_ref::<&Option<T>>()
-            .ok_or_else(|| Error::msg("Incorrect extern ref type."))?
-            .as_ref())
+            .downcast_ref::<T>()
+            .ok_or_else(|| Error::msg("Incorrect extern ref type."))?)
     }
 }
 

--- a/src/backend/backend_web/mod.rs
+++ b/src/backend/backend_web/mod.rs
@@ -340,14 +340,14 @@ impl FromStoredJs for Value<Engine> {
 pub struct ExternRef {}
 
 impl WasmExternRef<Engine> for ExternRef {
-    fn new<T: 'static + Send + Sync>(_: impl AsContextMut<Engine>, _: Option<T>) -> Self {
+    fn new<T: 'static + Send + Sync>(_: impl AsContextMut<Engine>, _: T) -> Self {
         unimplemented!("ExternRef is not supported in the web backend")
     }
 
-    fn downcast<'a, T: 'static, S: 'a>(
+    fn downcast<'a, 's: 'a, T: 'static, S: 's>(
         &self,
-        _: <Engine as WasmEngine>::StoreContext<'a, S>,
-    ) -> anyhow::Result<Option<&'a T>> {
+        _: <Engine as WasmEngine>::StoreContext<'s, S>,
+    ) -> anyhow::Result<&'a T> {
         unimplemented!()
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -344,12 +344,12 @@ pub trait WasmEngine: 'static + Clone + Sized {
 /// Provides a nullable opaque reference to any data within WebAssembly.
 pub trait WasmExternRef<E: WasmEngine>: Clone + Sized + Send + Sync {
     /// Creates a new reference wrapping the given value.
-    fn new<T: 'static + Send + Sync>(ctx: impl AsContextMut<E>, object: Option<T>) -> Self;
+    fn new<T: 'static + Send + Sync>(ctx: impl AsContextMut<E>, object: T) -> Self;
     /// Returns a shared reference to the underlying data.
-    fn downcast<'a, T: 'static, S: 'a>(
-        &self,
-        store: E::StoreContext<'a, S>,
-    ) -> Result<Option<&'a T>>;
+    fn downcast<'a, 's: 'a, T: 'static, S: 's>(
+        &'a self,
+        store: E::StoreContext<'s, S>,
+    ) -> Result<&'a T>;
 }
 
 /// Provides a Wasm or host function reference.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -899,23 +899,23 @@ impl ExternRef {
     /// Creates a new [`ExternRef`] wrapping the given value.
     pub fn new<T: 'static + Send + Sync, C: AsContextMut>(
         mut ctx: C,
-        object: impl Into<Option<T>>,
+        object: T,
     ) -> Self {
         Self {
             extern_ref: BackendObject::new(
                 <<C::Engine as WasmEngine>::ExternRef as WasmExternRef<C::Engine>>::new(
                     ctx.as_context_mut().inner,
-                    object.into(),
+                    object,
                 ),
             ),
         }
     }
 
     /// Returns a shared reference to the underlying data for this [`ExternRef`].
-    pub fn downcast<'a, T: 'static, S: 'a, E: WasmEngine>(
-        &self,
-        ctx: StoreContext<'a, S, E>,
-    ) -> Result<Option<&'a T>> {
+    pub fn downcast<'a, 's: 'a, T: 'static, S: 's, E: WasmEngine>(
+        &'a self,
+        ctx: StoreContext<'s, S, E>,
+    ) -> Result<&'a T> {
         self.extern_ref.cast::<E::ExternRef>().downcast(ctx.inner)
     }
 }


### PR DESCRIPTION
Re #5 

I wanted to see what a cleaned-up `ExternRef` API could look like. In this design, I've chosen to mirror the `wasmtime` API more, i.e. `None` is external to `ExternRef`.

I also noticed that the current API provides access to the inner data with the lifetime of the store, not the `ExternRef` borrow, which is implemented for the `wasmtime` wrapper in a way that has exploded my brain (somehow we go from a `'self` lifetime to an `'a` lifetime even though they are in no way related, and all by the downcast_ref to an `Option<&'self &Option>` [note that Rust does not allow writing this as `Option<&'self &'a Option>` since we have not guaranteed that `'a: 'self`] - does this ever succeed?). Only exposing the borrowed lifetime seems an easier choice that provides more flexibility to backends.

This change unfortunately disadvantages the `wasmi` backend which currently just implements `WasmExternRef` for `wasmi::ExternRef`, which can be constructed elsewhere, so someone could create an internal `None` and then pass it to the `wasm_runtime_layer` API which now longer supports internal `None`s. This could be solved by using a newtype wrapper (not yet done) to encode this assumption with a type boundary.

What are your thoughts on this proposed clean-up?