### PR TITLE
Upgrade `wasmtime_runtime_layer` to v19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ wasm-bindgen-test = "0.3"
 wat = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-wasmtime_runtime_layer = { version = "18.0", path = "backends/wasmtime_runtime_layer" }
+wasmtime_runtime_layer = { version = "19.0", path = "backends/wasmtime_runtime_layer" }
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/backends/js_wasm_runtime_layer/Cargo.toml
+++ b/backends/js_wasm_runtime_layer/Cargo.toml
@@ -16,7 +16,7 @@ js-sys = { version = "0.3", default-features = false }
 slab = { version = "0.4", default-features = false }
 smallvec.workspace = true
 tracing = { version = "0.1", default-features = false, optional = true }
-wasmparser = { version = "0.118", default-features = false }
+wasmparser = { version = "0.207", default-features = false, features = [ "std" ]}
 wasm-bindgen = { version = "0.2", default-features = false }
 wasm_runtime_layer.workspace = true
 

--- a/backends/wasmtime_runtime_layer/Cargo.toml
+++ b/backends/wasmtime_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime_runtime_layer"
-version = "18.0.0"
+version = "19.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ fxhash = { version = "0.2", default-features = false }
 ref-cast = { version = "1.0", default-features = false }
 smallvec = { version = "1.11", default-features = false }
 wasm_runtime_layer = { path = "../..", version = "0.4", default-features = false }
-wasmtime = { version = "18.0.0", default-features = false, features = [ "runtime" ] }
+wasmtime = { version = "19.0.0", default-features = false, features = [ "runtime", "gc" ] }
 
 [features]
 default = [ "cranelift" ]


### PR DESCRIPTION
This PR upgrades `wasmtime` to v19, which includes its migration to a separate `Ref` type. Since the `wasm_runtime_layer` still inlines all ref types in the `Value`, the asserts that `wasmtime` previously had against creating e.g. a table of type `i32` are now pushed up into the `wasm_runtime_layer`.

This PR also upgrades the `wasmparser` dependency for the `js_wasm_runtime_layer` but doesn't bump its version - this could be done if wanted or once more changes have been made to that backend.