### PR TITLE
Upgrade `wasmtime_runtime_layer` to v20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ wasm-bindgen-test = "0.3"
 wat = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-wasmtime_runtime_layer = { version = "19.0", path = "backends/wasmtime_runtime_layer" }
+wasmtime_runtime_layer = { version = "20.0", path = "backends/wasmtime_runtime_layer" }
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/backends/wasmtime_runtime_layer/Cargo.toml
+++ b/backends/wasmtime_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime_runtime_layer"
-version = "19.0.0"
+version = "20.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ fxhash = { version = "0.2", default-features = false }
 ref-cast = { version = "1.0", default-features = false }
 smallvec = { version = "1.11", default-features = false }
 wasm_runtime_layer = { path = "../..", version = "0.4", default-features = false }
-wasmtime = { version = "19.0.0", default-features = false, features = [ "runtime", "gc" ] }
+wasmtime = { version = "20.0.0", default-features = false, features = [ "runtime", "gc" ] }
 
 [features]
 default = [ "cranelift" ]


### PR DESCRIPTION
~~Blocked on #10~~

This PR upgrades `wasmtime` to v20, which includes its usage of `Rooted` GC reference types. It also introduces a new anyref type, which `wasm_runtime_layer` does not support.