### PR TITLE
Upgrade wasmtime to 22.0.0 and wasmi to 0.32.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,12 @@ smallvec.workspace = true
 
 [dev-dependencies]
 js_wasm_runtime_layer = { version = "0.4.0", path = "backends/js_wasm_runtime_layer" }
-wasmi_runtime_layer = { version = "0.31", path = "backends/wasmi_runtime_layer" }
+wasmi_runtime_layer = { version = "0.32", path = "backends/wasmi_runtime_layer" }
 wasm-bindgen-test = "0.3"
 wat = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-wasmtime_runtime_layer = { version = "21.0", path = "backends/wasmtime_runtime_layer" }
+wasmtime_runtime_layer = { version = "22.0", path = "backends/wasmtime_runtime_layer" }
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/backends/js_wasm_runtime_layer/Cargo.toml
+++ b/backends/js_wasm_runtime_layer/Cargo.toml
@@ -16,7 +16,7 @@ js-sys = { version = "0.3", default-features = false }
 slab = { version = "0.4", default-features = false }
 smallvec.workspace = true
 tracing = { version = "0.1", default-features = false, optional = true }
-wasmparser = { version = "0.208", default-features = false, features = [ "std" ]}
+wasmparser = { version = "0.211", default-features = false, features = [ "std" ]}
 wasm-bindgen = { version = "0.2", default-features = false }
 wasm_runtime_layer.workspace = true
 

--- a/backends/wasmi_runtime_layer/Cargo.toml
+++ b/backends/wasmi_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi_runtime_layer"
-version = "0.31.0"
+version = "0.32.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,4 +14,4 @@ anyhow.workspace = true
 ref-cast.workspace = true
 smallvec.workspace = true
 wasm_runtime_layer.workspace = true
-wasmi = { version = "0.31.0", default-features = false, features = [ "std" ] }
+wasmi = { version = "0.32.0", default-features = false, features = [ "std" ] }

--- a/backends/wasmtime_runtime_layer/Cargo.toml
+++ b/backends/wasmtime_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime_runtime_layer"
-version = "21.0.0"
+version = "22.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ fxhash = { version = "0.2", default-features = false }
 ref-cast = { version = "1.0", default-features = false }
 smallvec = { version = "1.11", default-features = false }
 wasm_runtime_layer = { path = "../..", version = "0.4", default-features = false }
-wasmtime = { version = "21.0.0", default-features = false, features = [ "runtime", "gc" ] }
+wasmtime = { version = "22.0.0", default-features = false, features = [ "runtime", "gc" ] }
 
 [features]
 default = [ "cranelift" ]


### PR DESCRIPTION
This PR upgrades `wasmtime` to v22 and `wasmi` to v32 and bumps their runtime crates to the matching versions.

The `wasmtime` update is without changes, `wasmi` needed some minor fixes.