### PR TITLE
Bump wasmi backend on 0.36

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ smallvec.workspace = true
 
 [dev-dependencies]
 js_wasm_runtime_layer = { version = "0.4.0", path = "backends/js_wasm_runtime_layer" }
-wasmi_runtime_layer = { version = "0.35", path = "backends/wasmi_runtime_layer" }
+wasmi_runtime_layer = { version = "0.36", path = "backends/wasmi_runtime_layer" }
 wasm-bindgen-test = "0.3"
 wat = "1.0"
 

--- a/backends/wasmi_runtime_layer/Cargo.toml
+++ b/backends/wasmi_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi_runtime_layer"
-version = "0.35.0"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,4 +14,4 @@ anyhow.workspace = true
 ref-cast.workspace = true
 smallvec.workspace = true
 wasm_runtime_layer.workspace = true
-wasmi = { version = "0.35.0", default-features = false, features = [ "std" ] }
+wasmi = { version = "0.36.0", default-features = false, features = [ "std" ] }


### PR DESCRIPTION
PR 4/3, this one contains version bumps for
- wasmi 0.36

Blocked on #17