### PR TITLE
Upgrade wasmtime-runtime-layer to v24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ smallvec = { version = "1.11", default-features = false }
 wasm_runtime_layer = { path = ".", version = "0.4.1" }
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/DouglasDwyer/wasm_runtime_layer"
@@ -44,7 +44,7 @@ wasm-bindgen-test = "0.3"
 wat = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-wasmtime_runtime_layer = { version = "23.0", path = "backends/wasmtime_runtime_layer" }
+wasmtime_runtime_layer = { version = "24.0", path = "backends/wasmtime_runtime_layer" }
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/backends/js_wasm_runtime_layer/Cargo.toml
+++ b/backends/js_wasm_runtime_layer/Cargo.toml
@@ -16,7 +16,7 @@ js-sys = { version = "0.3", default-features = false }
 slab = { version = "0.4", default-features = false }
 smallvec.workspace = true
 tracing = { version = "0.1", default-features = false, optional = true }
-wasmparser = { version = "0.214", default-features = false, features = [ "std" ]}
+wasmparser = { version = "0.215", default-features = false, features = [ "std" ]}
 wasm-bindgen = { version = "0.2", default-features = false }
 wasm_runtime_layer.workspace = true
 

--- a/backends/wasmtime_runtime_layer/Cargo.toml
+++ b/backends/wasmtime_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime_runtime_layer"
-version = "23.0.0"
+version = "24.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,8 +14,8 @@ anyhow = { version = "1.0", default-features = false, features = [ "std" ] }
 fxhash = { version = "0.2", default-features = false }
 ref-cast = { version = "1.0", default-features = false }
 smallvec = { version = "1.11", default-features = false }
-wasm_runtime_layer = { path = "../..", version = "0.4", default-features = false }
-wasmtime = { version = "23.0.0", default-features = false, features = [ "runtime", "gc" ] }
+wasm_runtime_layer = { path = "../..", version = "0.4.2", default-features = false }
+wasmtime = { version = "24.0.0", default-features = false, features = [ "runtime", "gc" ] }
 
 [features]
 default = [ "cranelift" ]

--- a/backends/wasmtime_runtime_layer/src/lib.rs
+++ b/backends/wasmtime_runtime_layer/src/lib.rs
@@ -230,8 +230,8 @@ impl WasmFunc<Engine> for Func {
 
 impl WasmGlobal<Engine> for Global {
     fn new(mut ctx: impl AsContextMut<Engine>, value: Value<Engine>, mutable: bool) -> Self {
+        let ty = value_type_into(value.ty());
         let value = value_into(value);
-        let ty = value.ty(ctx.as_context_mut().into_inner());
         Self::new(
             wasmtime::Global::new(
                 ctx.as_context_mut().into_inner(),

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -21,6 +21,21 @@ pub enum Value<E: WasmEngine> {
     ExternRef(Option<E::ExternRef>),
 }
 
+impl<E: WasmEngine> Value<E> {
+    /// Returns the [`ValueType`] for this [`Value`].
+    #[must_use]
+    pub const fn ty(&self) -> ValueType {
+        match self {
+            Value::I32(_) => ValueType::I32,
+            Value::I64(_) => ValueType::I64,
+            Value::F32(_) => ValueType::F32,
+            Value::F64(_) => ValueType::F64,
+            Value::FuncRef(_) => ValueType::FuncRef,
+            Value::ExternRef(_) => ValueType::ExternRef,
+        }
+    }
+}
+
 impl<E: WasmEngine> std::fmt::Debug for Value<E>
 where
     E::Func: std::fmt::Debug,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -832,6 +832,21 @@ pub enum Value {
     ExternRef(Option<ExternRef>),
 }
 
+impl Value {
+    /// Returns the [`ValueType`] for this [`Value`].
+    #[must_use]
+    pub const fn ty(&self) -> ValueType {
+        match self {
+            Value::I32(_) => ValueType::I32,
+            Value::I64(_) => ValueType::I64,
+            Value::F32(_) => ValueType::F32,
+            Value::F64(_) => ValueType::F64,
+            Value::FuncRef(_) => ValueType::FuncRef,
+            Value::ExternRef(_) => ValueType::ExternRef,
+        }
+    }
+}
+
 impl PartialEq for Value {
     fn eq(&self, o: &Self) -> bool {
         match (self, o) {


### PR DESCRIPTION
This is the regular version bump for `wasmtime_runtime_layer` to v24

This PR includes a small required change to the `wasm_runtime_layer` crate, which results in a minor version bump to 0.4.2: the `Value` (and `backend::Value`) types get a new `ty(&self) -> ValueType` method. This method is required to use `wasmtime` v24 without introducing an unnecessary panic path.