### PR TITLE
Bump wasmi_runtime_layer to v0.37

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ ref-cast.workspace = true
 smallvec.workspace = true
 
 [dev-dependencies]
-js_wasm_runtime_layer = { version = "0.4.0", path = "backends/js_wasm_runtime_layer" }
-wasmi_runtime_layer = { version = "0.36", path = "backends/wasmi_runtime_layer" }
+js_wasm_runtime_layer = { version = "0.4", path = "backends/js_wasm_runtime_layer" }
+wasmi_runtime_layer = { version = "0.37", path = "backends/wasmi_runtime_layer" }
 wasm-bindgen-test = "0.3"
 wat = "1.0"
 

--- a/backends/js_wasm_runtime_layer/Cargo.toml
+++ b/backends/js_wasm_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "js_wasm_runtime_layer"
-version.workspace = true
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/backends/wasmi_runtime_layer/Cargo.toml
+++ b/backends/wasmi_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi_runtime_layer"
-version = "0.36.0"
+version = "0.37.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,4 +14,4 @@ anyhow.workspace = true
 ref-cast.workspace = true
 smallvec.workspace = true
 wasm_runtime_layer.workspace = true
-wasmi = { version = "0.36.0", default-features = false, features = [ "std" ] }
+wasmi = { version = "0.37", default-features = false, features = [ "std" ] }


### PR DESCRIPTION
This PR includes the version bump for wasmi, which requires no implementation changes, and some minor workspace cleanup.

The new version 0.37.0 for `wasmi_runtime_layer` should be released after merging this PR