### PR TITLE
Upgrade wasmtime_runtime_layer to v26.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ wasm-bindgen-test = "0.3"
 wat = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-wasmtime_runtime_layer = { version = "25.0", path = "backends/wasmtime_runtime_layer" }
+wasmtime_runtime_layer = { version = "26.0", path = "backends/wasmtime_runtime_layer" }
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/backends/js_wasm_runtime_layer/Cargo.toml
+++ b/backends/js_wasm_runtime_layer/Cargo.toml
@@ -16,7 +16,7 @@ js-sys = { version = "0.3", default-features = false }
 slab = { version = "0.4", default-features = false }
 smallvec.workspace = true
 tracing = { version = "0.1", default-features = false, optional = true }
-wasmparser = { version = "0.218", default-features = false, features = [ "std" ]}
+wasmparser = { version = "0.219", default-features = false, features = [ "std", "component-model" ]}
 wasm-bindgen = { version = "0.2", default-features = false }
 wasm_runtime_layer.workspace = true
 

--- a/backends/js_wasm_runtime_layer/src/module.rs
+++ b/backends/js_wasm_runtime_layer/src/module.rs
@@ -135,7 +135,6 @@ pub(crate) fn parse_module(bytes: &[u8]) -> anyhow::Result<ParsedModule> {
 
     parser.parse_all(bytes).try_for_each(|payload| {
         match payload? {
-            wasmparser::Payload::Version { .. } => {}
             wasmparser::Payload::TypeSection(section) => {
                 for ty in section {
                     let ty = ty?;
@@ -244,7 +243,6 @@ pub(crate) fn parse_module(bytes: &[u8]) -> anyhow::Result<ParsedModule> {
                     exports.insert(export.name.to_string(), ty);
                 }
             }
-            wasmparser::Payload::StartSection { .. } => {}
             wasmparser::Payload::ElementSection(_section) =>
             {
                 #[cfg(feature = "tracing")]
@@ -257,24 +255,7 @@ pub(crate) fn parse_module(bytes: &[u8]) -> anyhow::Result<ParsedModule> {
                     }
                 }
             }
-            wasmparser::Payload::DataCountSection { .. } => {}
-            wasmparser::Payload::DataSection(_) => {}
-            wasmparser::Payload::CodeSectionStart { .. } => {}
-            wasmparser::Payload::CodeSectionEntry(_) => {}
-            wasmparser::Payload::ModuleSection { .. } => {}
-            wasmparser::Payload::InstanceSection(_) => {}
-            wasmparser::Payload::CoreTypeSection(_) => {}
-            wasmparser::Payload::ComponentSection { .. } => {}
-            wasmparser::Payload::ComponentInstanceSection(_) => {}
-            wasmparser::Payload::ComponentAliasSection(_) => {}
-            wasmparser::Payload::ComponentTypeSection(_) => {}
-            wasmparser::Payload::ComponentCanonicalSection(_) => {}
-            wasmparser::Payload::ComponentStartSection { .. } => {}
-            wasmparser::Payload::ComponentImportSection(_) => {}
-            wasmparser::Payload::ComponentExportSection(_) => {}
-            wasmparser::Payload::CustomSection(_) => {}
-            wasmparser::Payload::UnknownSection { .. } => {}
-            wasmparser::Payload::End(_) => {}
+            _ => {}
         }
 
         anyhow::Ok(())

--- a/backends/wasmtime_runtime_layer/Cargo.toml
+++ b/backends/wasmtime_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime_runtime_layer"
-version = "25.0.0"
+version = "26.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ fxhash = { version = "0.2", default-features = false }
 ref-cast = { version = "1.0", default-features = false }
 smallvec = { version = "1.11", default-features = false }
 wasm_runtime_layer = { path = "../..", version = "0.4.2", default-features = false }
-wasmtime = { version = "25.0", default-features = false, features = [ "runtime", "gc" ] }
+wasmtime = { version = "26.0", default-features = false, features = [ "runtime", "gc" ] }
 
 [features]
 default = [ "cranelift" ]


### PR DESCRIPTION
This time there are API changes in wasmtime v26: it now supports table64 by default, so we to convert between `u64` and `u32` for table sizes

Also, in my continuous effort to keep the `js_wasmtime_runtime_layer` dependencies up-to-date, `wasmparser::Payload` is now non-exhaustive and I thought it would look silly to have so many no-op cases *and* a catch-all, so I combined them.