### PR TITLE
Bump wasmtime to v27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ wasm-bindgen-test = "0.3"
 wat = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+wasmtime = { version = "27.0", default-features = false, features = [ "gc-null" ] }
 wasmtime_runtime_layer = { version = "27.0", path = "backends/wasmtime_runtime_layer" }
 
 [package.metadata."docs.rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ wasm-bindgen-test = "0.3"
 wat = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-wasmtime_runtime_layer = { version = "26.0", path = "backends/wasmtime_runtime_layer" }
+wasmtime_runtime_layer = { version = "27.0", path = "backends/wasmtime_runtime_layer" }
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/backends/js_wasm_runtime_layer/Cargo.toml
+++ b/backends/js_wasm_runtime_layer/Cargo.toml
@@ -16,7 +16,7 @@ js-sys = { version = "0.3", default-features = false }
 slab = { version = "0.4", default-features = false }
 smallvec.workspace = true
 tracing = { version = "0.1", default-features = false, optional = true }
-wasmparser = { version = "0.219", default-features = false, features = [ "std", "component-model" ]}
+wasmparser = { version = "0.220", default-features = false, features = [ "std" ]}
 wasm-bindgen = { version = "0.2", default-features = false }
 wasm_runtime_layer.workspace = true
 

--- a/backends/wasmtime_runtime_layer/Cargo.toml
+++ b/backends/wasmtime_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime_runtime_layer"
-version = "26.0.0"
+version = "27.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ fxhash = { version = "0.2", default-features = false }
 ref-cast = { version = "1.0", default-features = false }
 smallvec = { version = "1.11", default-features = false }
 wasm_runtime_layer = { path = "../..", version = "0.4.2", default-features = false }
-wasmtime = { version = "26.0", default-features = false, features = [ "runtime", "gc" ] }
+wasmtime = { version = "27.0", default-features = false, features = [ "runtime", "gc" ] }
 
 [features]
 default = [ "cranelift" ]

--- a/backends/wasmtime_runtime_layer/src/lib.rs
+++ b/backends/wasmtime_runtime_layer/src/lib.rs
@@ -158,6 +158,7 @@ impl WasmExternRef<Engine> for ExternRef {
         ctx: StoreContext<'s, S>,
     ) -> Result<&'a T> {
         self.data(ctx.into_inner())?
+            .ok_or_else(|| Error::msg("extern ref must not be a wrapped anyref"))?
             .downcast_ref::<T>()
             .ok_or_else(|| Error::msg("Incorrect extern ref type."))
     }


### PR DESCRIPTION
There are just two noteworthy changes in this PR:
- downcasting externrefs now needs to check that they're not anyrefs
- running wasmtime tests now requires enabling one gc implementation feature - since we don't want to choose for users, we only enable it in our tests but not in the wasmtime-runtime-layer crate itself