### PR TITLE
Add `std` feature to all crates for no-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false, features = [ "std" ] }
 fxhash = { version = "0.2", default-features = false }
+hashbrown = { version = "0.15", default-features = false }
 ref-cast = { version = "1.0", default-features = false }
 smallvec = { version = "1.11", default-features = false }
 wasm_runtime_layer = { path = ".", version = "0.4.2" }
@@ -33,6 +34,7 @@ Compatibility interface for WASM runtimes.
 [dependencies]
 anyhow.workspace = true
 fxhash.workspace = true
+hashbrown.workspace = true
 ref-cast.workspace = true
 smallvec.workspace = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,21 +22,21 @@ repository = "https://github.com/DouglasDwyer/wasm_runtime_layer"
 
 [package]
 name = "wasm_runtime_layer"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
-repository.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 readme = "README.md"
 description = """
 Compatibility interface for WASM runtimes.
 """
 
 [dependencies]
-anyhow.workspace = true
-fxhash.workspace = true
-hashbrown.workspace = true
-ref-cast.workspace = true
-smallvec.workspace = true
+anyhow = { workspace = true }
+fxhash = { workspace = true }
+hashbrown = { workspace = true }
+ref-cast = { workspace = true }
+smallvec = { workspace = true }
 
 [features]
 default = [ "std" ]
@@ -45,8 +45,8 @@ std = [ "anyhow/std" ]
 [dev-dependencies]
 js_wasm_runtime_layer = { version = "0.4", path = "backends/js_wasm_runtime_layer" }
 wasmi_runtime_layer = { version = "0.40", path = "backends/wasmi_runtime_layer" }
-wasm-bindgen-test = "0.3"
-wat = "1.0"
+wasm-bindgen-test = { version = "0.3" }
+wat = { version = "1.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 wasmtime = { version = "30.0", default-features = false, features = [ "gc-null" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,16 @@ fxhash = { version = "0.2", default-features = false }
 hashbrown = { version = "0.15", default-features = false }
 ref-cast = { version = "1.0", default-features = false }
 smallvec = { version = "1.11", default-features = false }
-wasm_runtime_layer = { path = ".", version = "0.4.2", default-features = false }
+wasm_runtime_layer = { path = ".", version = "0.5", default-features = false }
 
 [workspace.package]
-version = "0.4.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/DouglasDwyer/wasm_runtime_layer"
 
 [package]
 name = "wasm_runtime_layer"
-version = { workspace = true }
+version = "0.5.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ members = [
 ]
 
 [workspace.dependencies]
-anyhow = { version = "1.0", default-features = false, features = [ "std" ] }
+anyhow = { version = "1.0", default-features = false }
 fxhash = { version = "0.2", default-features = false }
 hashbrown = { version = "0.15", default-features = false }
 ref-cast = { version = "1.0", default-features = false }
 smallvec = { version = "1.11", default-features = false }
-wasm_runtime_layer = { path = ".", version = "0.4.2" }
+wasm_runtime_layer = { path = ".", version = "0.4.2", default-features = false }
 
 [workspace.package]
 version = "0.4.2"
@@ -37,6 +37,10 @@ fxhash.workspace = true
 hashbrown.workspace = true
 ref-cast.workspace = true
 smallvec.workspace = true
+
+[features]
+default = [ "std" ]
+std = [ "anyhow/std" ]
 
 [dev-dependencies]
 js_wasm_runtime_layer = { version = "0.4", path = "backends/js_wasm_runtime_layer" }

--- a/backends/js_wasm_runtime_layer/Cargo.toml
+++ b/backends/js_wasm_runtime_layer/Cargo.toml
@@ -1,24 +1,26 @@
 [package]
 name = "js_wasm_runtime_layer"
 version = "0.4.0"
-edition.workspace = true
-license.workspace = true
-repository.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 readme = "README.md"
 description = """
 WebAssembly runtime compatibility interface implementation for your web browser's WebAssembly runtime.
 """
 
 [dependencies]
-anyhow.workspace = true
-fxhash.workspace = true
+anyhow = { workspace = true }
+fxhash = { workspace = true }
 js-sys = { version = "0.3", default-features = false }
 slab = { version = "0.4", default-features = false }
-smallvec.workspace = true
+smallvec = { workspace = true }
 tracing = { version = "0.1", default-features = false, optional = true }
 wasmparser = { version = "0.226", default-features = false, features = [ "std" ]}
 wasm-bindgen = { version = "0.2", default-features = false }
-wasm_runtime_layer.workspace = true
+wasm_runtime_layer = { workspace = true }
 
 [features]
-tracing = ["dep:tracing"]
+default = [ "std" ]
+std = [ "anyhow/std", "wasm_runtime_layer/std" ]
+tracing = [ "dep:tracing" ]

--- a/backends/js_wasm_runtime_layer/src/func.rs
+++ b/backends/js_wasm_runtime_layer/src/func.rs
@@ -1,3 +1,5 @@
+use alloc::vec;
+
 use anyhow::Context;
 use js_sys::{Array, Function};
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};

--- a/backends/js_wasm_runtime_layer/src/instance.rs
+++ b/backends/js_wasm_runtime_layer/src/instance.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use alloc::{boxed::Box, collections::BTreeMap, string::String, vec::Vec};
 
 use anyhow::{bail, Context};
 use fxhash::FxHashMap;

--- a/backends/js_wasm_runtime_layer/src/lib.rs
+++ b/backends/js_wasm_runtime_layer/src/lib.rs
@@ -1,6 +1,6 @@
-#![deny(warnings)]
 #![warn(missing_docs)]
 #![warn(clippy::missing_docs_in_private_items)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! `js_wasm_runtime_layer` implements the `wasm_runtime_layer` abstraction interface over WebAssembly runtimes for your web browser's WebAssembly runtime.
 

--- a/backends/js_wasm_runtime_layer/src/module.rs
+++ b/backends/js_wasm_runtime_layer/src/module.rs
@@ -52,18 +52,6 @@ impl WasmModule<Engine> for Module {
         Ok(module)
     }
 
-    #[cfg(feature = "std")]
-    fn new_streaming(engine: &Engine, mut stream: impl std::io::Read) -> anyhow::Result<Self> {
-        use anyhow::Context;
-
-        let mut buf = Vec::new();
-        stream
-            .read_to_end(&mut buf)
-            .context("Failed to read module bytes")?;
-
-        Self::new(engine, buf.as_slice())
-    }
-
     fn exports(&self) -> Box<dyn '_ + Iterator<Item = ExportType<'_>>> {
         Box::new(self.parsed.exports.iter().map(|(name, ty)| ExportType {
             name: name.as_str(),

--- a/backends/js_wasm_runtime_layer/src/module.rs
+++ b/backends/js_wasm_runtime_layer/src/module.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 
 use anyhow::Context;
 use fxhash::FxHashMap;

--- a/backends/js_wasm_runtime_layer/src/module.rs
+++ b/backends/js_wasm_runtime_layer/src/module.rs
@@ -5,7 +5,6 @@ use alloc::{
     vec::Vec,
 };
 
-use anyhow::Context;
 use fxhash::FxHashMap;
 use js_sys::{Uint8Array, WebAssembly};
 use wasm_runtime_layer::{
@@ -55,6 +54,8 @@ impl WasmModule<Engine> for Module {
 
     #[cfg(feature = "std")]
     fn new_streaming(engine: &Engine, mut stream: impl std::io::Read) -> anyhow::Result<Self> {
+        use anyhow::Context;
+
         let mut buf = Vec::new();
         stream
             .read_to_end(&mut buf)

--- a/backends/js_wasm_runtime_layer/src/store.rs
+++ b/backends/js_wasm_runtime_layer/src/store.rs
@@ -1,5 +1,6 @@
-use std::{
-    mem,
+use alloc::{boxed::Box, vec::Vec};
+use core::{
+    fmt, mem,
     ops::{Deref, DerefMut},
 };
 
@@ -148,8 +149,8 @@ impl<T> AsContextMut<Engine> for Store<T> {
     }
 }
 
-impl<T: std::fmt::Debug> std::fmt::Debug for Store<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: fmt::Debug> fmt::Debug for Store<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }

--- a/backends/js_wasm_runtime_layer/src/table.rs
+++ b/backends/js_wasm_runtime_layer/src/table.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use anyhow::Context;
 use js_sys::{Object, Reflect, WebAssembly};
 use wasm_bindgen::{JsCast, JsValue};
@@ -26,8 +28,8 @@ pub(crate) struct TableInner {
     ty: TableType,
 }
 
-impl std::fmt::Debug for TableInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for TableInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TableInner")
             .field("ty", &self.ty)
             .field("inner", &self.table)

--- a/backends/wasmi_runtime_layer/Cargo.toml
+++ b/backends/wasmi_runtime_layer/Cargo.toml
@@ -1,17 +1,21 @@
 [package]
 name = "wasmi_runtime_layer"
 version = "0.40.0"
-edition.workspace = true
-license.workspace = true
-repository.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 readme = "README.md"
 description = """
 WebAssembly runtime compatibility interface implementation for Wasmi.
 """
 
 [dependencies]
-anyhow.workspace = true
-ref-cast.workspace = true
-smallvec.workspace = true
-wasm_runtime_layer.workspace = true
-wasmi = { version = "0.40", default-features = false, features = [ "std" ] }
+anyhow = { workspace = true }
+ref-cast = { workspace = true }
+smallvec = { workspace = true }
+wasm_runtime_layer = { workspace = true }
+wasmi = { version = "0.40", default-features = false }
+
+[features]
+default = [ "std" ]
+std = [ "anyhow/std", "wasmi/std", "wasm_runtime_layer/std" ]

--- a/backends/wasmi_runtime_layer/src/lib.rs
+++ b/backends/wasmi_runtime_layer/src/lib.rs
@@ -394,14 +394,6 @@ impl WasmModule<Engine> for Module {
         ))
     }
 
-    #[cfg(feature = "std")]
-    fn new_streaming(engine: &Engine, stream: impl std::io::Read) -> Result<Self> {
-        Ok(Self::new(wasmi::Module::new_streaming(
-            engine.as_ref(),
-            stream,
-        )?))
-    }
-
     fn exports(&self) -> Box<dyn '_ + Iterator<Item = ExportType<'_>>> {
         Box::new(self.as_ref().exports().map(|x| ExportType {
             name: x.name(),

--- a/backends/wasmi_runtime_layer/src/lib.rs
+++ b/backends/wasmi_runtime_layer/src/lib.rs
@@ -1,7 +1,7 @@
-#![deny(warnings)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(clippy::missing_docs_in_private_items)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! `wasmi_runtime_layer` implements the `wasm_runtime_layer` abstraction interface over WebAssembly runtimes for `Wasmi`.
 
@@ -379,7 +379,12 @@ impl WasmMemory<Engine> for Memory {
 }
 
 impl WasmModule<Engine> for Module {
-    fn new(engine: &Engine, stream: impl std::io::Read) -> Result<Self> {
+    fn new(engine: &Engine, bytes: &[u8]) -> Result<Self> {
+        Ok(Self::new(wasmi::Module::new(engine.as_ref(), bytes)?))
+    }
+
+    #[cfg(feature = "std")]
+    fn new_streaming(engine: &Engine, stream: impl std::io::Read) -> Result<Self> {
         Ok(Self::new(wasmi::Module::new_streaming(
             engine.as_ref(),
             stream,

--- a/backends/wasmi_runtime_layer/src/lib.rs
+++ b/backends/wasmi_runtime_layer/src/lib.rs
@@ -5,7 +5,13 @@
 
 //! `wasmi_runtime_layer` implements the `wasm_runtime_layer` abstraction interface over WebAssembly runtimes for `Wasmi`.
 
-use std::ops::{Deref, DerefMut};
+extern crate alloc;
+
+use alloc::{boxed::Box, vec::Vec};
+use core::{
+    fmt,
+    ops::{Deref, DerefMut},
+};
 
 use anyhow::{Error, Result};
 use ref_cast::RefCast;
@@ -662,8 +668,8 @@ fn extern_type_from(ty: wasmi::ExternType) -> ExternType {
 #[derive(Debug)]
 struct HostError(anyhow::Error);
 
-impl std::fmt::Display for HostError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for HostError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/backends/wasmi_runtime_layer/src/lib.rs
+++ b/backends/wasmi_runtime_layer/src/lib.rs
@@ -7,7 +7,7 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, string::ToString, vec::Vec};
 use core::{
     fmt,
     ops::{Deref, DerefMut},

--- a/backends/wasmtime_runtime_layer/Cargo.toml
+++ b/backends/wasmtime_runtime_layer/Cargo.toml
@@ -10,7 +10,7 @@ WebAssembly runtime compatibility interface implementation for Wasmtime.
 """
 
 [dependencies]
-anyhow = { version = "1.0", default-features = false, features = [ "std" ] }
+anyhow = { version = "1.0", default-features = false }
 fxhash = { version = "0.2", default-features = false }
 ref-cast = { version = "1.0", default-features = false }
 smallvec = { version = "1.11", default-features = false }
@@ -18,7 +18,8 @@ wasm_runtime_layer = { path = "../..", version = "0.4.2", default-features = fal
 wasmtime = { version = "30.0", default-features = false, features = [ "runtime", "gc" ] }
 
 [features]
-default = [ "cranelift" ]
+default = [ "cranelift", "std" ]
+std = [ "anyhow/std", "wasm_runtime_layer/std" ]
 
 cranelift = [ "wasmtime/cranelift" ]
 winch = [ "wasmtime/winch" ]

--- a/backends/wasmtime_runtime_layer/Cargo.toml
+++ b/backends/wasmtime_runtime_layer/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "wasmtime_runtime_layer"
 version = "30.0.0"
-edition.workspace = true
-license.workspace = true
-repository.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 readme = "README.md"
 description = """
 WebAssembly runtime compatibility interface implementation for Wasmtime.

--- a/backends/wasmtime_runtime_layer/Cargo.toml
+++ b/backends/wasmtime_runtime_layer/Cargo.toml
@@ -10,11 +10,11 @@ WebAssembly runtime compatibility interface implementation for Wasmtime.
 """
 
 [dependencies]
-anyhow = { version = "1.0", default-features = false }
-fxhash = { version = "0.2", default-features = false }
-ref-cast = { version = "1.0", default-features = false }
-smallvec = { version = "1.11", default-features = false }
-wasm_runtime_layer = { path = "../..", version = "0.4.2", default-features = false }
+anyhow = { workspace = true }
+fxhash = { workspace = true }
+ref-cast = { workspace = true }
+smallvec = { workspace = true }
+wasm_runtime_layer = { workspace = true }
 wasmtime = { version = "30.0", default-features = false, features = [ "runtime", "gc" ] }
 
 [features]

--- a/backends/wasmtime_runtime_layer/src/lib.rs
+++ b/backends/wasmtime_runtime_layer/src/lib.rs
@@ -10,10 +10,10 @@
 //!
 //! **winch** - Enables executing WASM modules and components with the Winch compiler, as described in the Wasmtime documentation.
 
-use std::{
-    ops::{Deref, DerefMut},
-    sync::Arc,
-};
+extern crate alloc;
+
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
+use core::ops::{Deref, DerefMut};
 
 use anyhow::{Error, Result};
 use fxhash::FxHashMap;
@@ -194,7 +194,7 @@ impl WasmFunc<Engine> for Func {
                     results[i] = value_into(result);
                 }
 
-                std::result::Result::Ok(())
+                Ok(())
             },
         ))
     }

--- a/backends/wasmtime_runtime_layer/src/lib.rs
+++ b/backends/wasmtime_runtime_layer/src/lib.rs
@@ -405,13 +405,6 @@ impl WasmModule<Engine> for Module {
         wasmtime::Module::from_binary(engine, bytes).map(Self::new)
     }
 
-    #[cfg(feature = "std")]
-    fn new_streaming(engine: &Engine, mut stream: impl std::io::Read) -> Result<Self> {
-        let mut buf = Vec::default();
-        stream.read_to_end(&mut buf)?;
-        <Self as WasmModule<Engine>>::new(engine, buf.as_slice())
-    }
-
     fn exports(&self) -> Box<dyn '_ + Iterator<Item = ExportType<'_>>> {
         Box::new(self.as_ref().exports().map(|x| ExportType {
             name: x.name(),

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,4 +1,7 @@
-use alloc::{boxed::Box, string::String};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
 use core::fmt;
 
 use anyhow::Result;
@@ -439,8 +442,11 @@ pub trait WasmInstance<E: WasmEngine>: Clone + Sized + Send + Sync {
 
 /// Provides a parsed and validated WASM module.
 pub trait WasmModule<E: WasmEngine>: Clone + Sized + Send + Sync {
+    /// Creates a new module from the given byte slice.
+    fn new(engine: &E, bytes: &[u8]) -> Result<Self>;
+    #[cfg(feature = "std")]
     /// Creates a new module from the given byte stream.
-    fn new(engine: &E, stream: impl std::io::Read) -> Result<Self>;
+    fn new_streaming(engine: &E, stream: impl std::io::Read) -> Result<Self>;
     /// Gets the export types of the module.
     fn exports(&self) -> Box<dyn '_ + Iterator<Item = ExportType<'_>>>;
     /// Gets the export type of the given name, if any, from this module.

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,8 +1,13 @@
-use crate::*;
-use anyhow::*;
-use fxhash::*;
-use std::marker::*;
-use std::ops::*;
+use alloc::{boxed::Box, string::String};
+use core::fmt;
+
+use anyhow::Result;
+use fxhash::FxBuildHasher;
+use hashbrown::HashMap;
+
+use crate::{
+    ExportType, ExternType, FuncType, GlobalType, ImportType, MemoryType, TableType, ValueType,
+};
 
 /// Runtime representation of a value.
 #[derive(Clone)]
@@ -36,12 +41,12 @@ impl<E: WasmEngine> Value<E> {
     }
 }
 
-impl<E: WasmEngine> std::fmt::Debug for Value<E>
+impl<E: WasmEngine> fmt::Debug for Value<E>
 where
-    E::Func: std::fmt::Debug,
-    E::ExternRef: std::fmt::Debug,
+    E::Func: fmt::Debug,
+    E::ExternRef: fmt::Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Value::I32(v) => f.debug_tuple("I32").field(v).finish(),
             Value::I64(v) => f.debug_tuple("I64").field(v).finish(),
@@ -137,14 +142,14 @@ impl<E: WasmEngine> Clone for Extern<E> {
     }
 }
 
-impl<E: WasmEngine> std::fmt::Debug for Extern<E>
+impl<E: WasmEngine> fmt::Debug for Extern<E>
 where
-    E::Global: std::fmt::Debug,
-    E::Func: std::fmt::Debug,
-    E::Memory: std::fmt::Debug,
-    E::Table: std::fmt::Debug,
+    E::Global: fmt::Debug,
+    E::Func: fmt::Debug,
+    E::Memory: fmt::Debug,
+    E::Table: fmt::Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Global(arg0) => f.debug_tuple("Global").field(arg0).finish(),
             Self::Table(arg0) => f.debug_tuple("Table").field(arg0).finish(),
@@ -166,11 +171,11 @@ pub struct Export<E: WasmEngine> {
     pub value: Extern<E>,
 }
 
-impl<E: WasmEngine> std::fmt::Debug for Export<E>
+impl<E: WasmEngine> fmt::Debug for Export<E>
 where
-    Extern<E>: std::fmt::Debug,
+    Extern<E>: fmt::Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Export")
             .field("name", &self.name)
             .field("value", &self.value)
@@ -182,14 +187,14 @@ where
 #[derive(Clone)]
 pub struct Imports<E: WasmEngine> {
     /// The inner list of external imports.
-    pub(crate) map: FxHashMap<(String, String), Extern<E>>,
+    pub(crate) map: HashMap<(String, String), Extern<E>, FxBuildHasher>,
 }
 
 impl<E: WasmEngine> Imports<E> {
     /// Create a new `Imports`.
     pub fn new() -> Self {
         Self {
-            map: FxHashMap::default(),
+            map: HashMap::default(),
         }
     }
 
@@ -239,7 +244,7 @@ impl<E: WasmEngine> Imports<E> {
 /// An iterator over imports.
 pub struct ImportsIterator<'a, E: WasmEngine> {
     /// The inner iterator over external items.
-    iter: std::collections::hash_map::Iter<'a, (String, String), Extern<E>>,
+    iter: hashbrown::hash_map::Iter<'a, (String, String), Extern<E>>,
 }
 
 impl<'a, E: WasmEngine> ImportsIterator<'a, E> {
@@ -261,7 +266,7 @@ impl<'a, E: WasmEngine> Iterator for ImportsIterator<'a, E> {
 }
 
 impl<E: WasmEngine> IntoIterator for &Imports<E> {
-    type IntoIter = std::collections::hash_map::IntoIter<(String, String), Extern<E>>;
+    type IntoIter = hashbrown::hash_map::IntoIter<(String, String), Extern<E>>;
     type Item = ((String, String), Extern<E>);
 
     fn into_iter(self) -> Self::IntoIter {
@@ -283,8 +288,8 @@ impl<E: WasmEngine> Extend<((String, String), Extern<E>)> for Imports<E> {
     }
 }
 
-impl<E: WasmEngine> std::fmt::Debug for Imports<E> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl<E: WasmEngine> fmt::Debug for Imports<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         /// Stores backing debug data.
         enum SecretMap {
             /// The empty variant.
@@ -304,8 +309,8 @@ impl<E: WasmEngine> std::fmt::Debug for Imports<E> {
             }
         }
 
-        impl std::fmt::Debug for SecretMap {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        impl fmt::Debug for SecretMap {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 match self {
                     Self::Empty => write!(f, "(empty)"),
                     Self::Some(len) => write!(f, "(... {} item(s) ...)", len),

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -444,9 +444,6 @@ pub trait WasmInstance<E: WasmEngine>: Clone + Sized + Send + Sync {
 pub trait WasmModule<E: WasmEngine>: Clone + Sized + Send + Sync {
     /// Creates a new module from the given byte slice.
     fn new(engine: &E, bytes: &[u8]) -> Result<Self>;
-    #[cfg(feature = "std")]
-    /// Creates a new module from the given byte stream.
-    fn new_streaming(engine: &E, stream: impl std::io::Read) -> Result<Self>;
     /// Gets the export types of the module.
     fn exports(&self) -> Box<dyn '_ + Iterator<Item = ExportType<'_>>>;
     /// Gets the export type of the given name, if any, from this module.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1070,20 +1070,6 @@ impl Module {
         })
     }
 
-    #[cfg(feature = "std")]
-    /// Creates a new Wasm [`Module`] from the given byte stream.
-    pub fn new_streaming<E: WasmEngine>(
-        engine: &Engine<E>,
-        stream: impl std::io::Read,
-    ) -> Result<Self> {
-        Ok(Self {
-            module: BackendObject::new(<E::Module as WasmModule<E>>::new_streaming(
-                &engine.backend,
-                stream,
-            )?),
-        })
-    }
-
     /// Returns an iterator over the exports of the [`Module`].
     pub fn exports<E: WasmEngine>(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! )
 //! .unwrap();
 //!
-//! let module = Module::new(&engine, std::io::Cursor::new(&module_bin)).unwrap();
+//! let module = Module::new(&engine, &module_bin).unwrap();
 //! let instance = Instance::new(&mut store, &module, &Imports::default()).unwrap();
 //!
 //! let add_one = instance

--- a/tests/add_one.rs
+++ b/tests/add_one.rs
@@ -41,7 +41,7 @@ fn add_one(engine: &Engine<impl WasmEngine>) {
     )
     .unwrap();
 
-    let module = Module::new(engine, std::io::Cursor::new(&module_bin)).unwrap();
+    let module = Module::new(engine, &module_bin).unwrap();
     let instance = Instance::new(&mut store, &module, &Imports::default()).unwrap();
 
     let add_one = instance

--- a/tests/multi_value.rs
+++ b/tests/multi_value.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, io::Cursor};
+use std::collections::BTreeMap;
 
 use wasm_runtime_layer::{
     backend::WasmEngine, Engine, Extern, Func, FuncType, Imports, Instance, Module, Store, Value,
@@ -71,7 +71,7 @@ fn multi_value(engine: &Engine<impl WasmEngine>) {
     imports.define("host", "get-values", crate::Extern::Func(func));
 
     // Parse the component bytes and load its imports and exports.
-    let module = Module::new(engine, Cursor::new(&module_bin)).unwrap();
+    let module = Module::new(engine, &module_bin).unwrap();
     let instance = Instance::new(&mut store, &module, &imports).unwrap();
 
     let exports = instance


### PR DESCRIPTION
Re #36

This PR upgrades all crates to be almost no-std. Unfortunately, `wasm_runtime_layer` cannot be fully no-std yet, since `std::io::Read` is std-only (see https://github.com/rust-lang/rust/issues/48331), which is used in `Module::new`.

This PR could be merged as a step in the right direction, with the hope that we might be able to be fully no-std once `std::io::Read` lives in `alloc`. Alternatively, we could make a breaking change to the API to not rely on `std::io::Read`.