### PR TITLE
Upgrade wasmi_runtime_layer to v0.41

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ std = [ "anyhow/std" ]
 
 [dev-dependencies]
 js_wasm_runtime_layer = { version = "0.4", path = "backends/js_wasm_runtime_layer" }
-wasmi_runtime_layer = { version = "0.40", path = "backends/wasmi_runtime_layer" }
+wasmi_runtime_layer = { version = "0.41", path = "backends/wasmi_runtime_layer" }
 wasm-bindgen-test = { version = "0.3" }
 wat = { version = "1.0" }
 

--- a/backends/js_wasm_runtime_layer/Cargo.toml
+++ b/backends/js_wasm_runtime_layer/Cargo.toml
@@ -16,7 +16,7 @@ js-sys = { version = "0.3", default-features = false }
 slab = { version = "0.4", default-features = false }
 smallvec = { workspace = true }
 tracing = { version = "0.1", default-features = false, optional = true }
-wasmparser = { version = "0.226", default-features = false, features = [ "std" ]}
+wasmparser = { version = "0.227", default-features = false, features = [ "std" ]}
 wasm-bindgen = { version = "0.2", default-features = false }
 wasm_runtime_layer = { workspace = true }
 

--- a/backends/wasmi_runtime_layer/Cargo.toml
+++ b/backends/wasmi_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi_runtime_layer"
-version = "0.40.0"
+version = "0.41.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
@@ -14,7 +14,7 @@ anyhow = { workspace = true }
 ref-cast = { workspace = true }
 smallvec = { workspace = true }
 wasm_runtime_layer = { workspace = true }
-wasmi = { version = "0.40", default-features = false }
+wasmi = { version = "0.41", default-features = false }
 
 [features]
 default = [ "std" ]


### PR DESCRIPTION
wasmi 0.41 adds support for memory64 and table64, so I've reused our approach from wasmtime to restrict support to 32bit only