### PR TITLE
Bump wasmi_runtime_layer to v0.42

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ std = [ "anyhow/std" ]
 
 [dev-dependencies]
 js_wasm_runtime_layer = { version = "0.4", path = "backends/js_wasm_runtime_layer" }
-wasmi_runtime_layer = { version = "0.41", path = "backends/wasmi_runtime_layer" }
+wasmi_runtime_layer = { version = "0.42", path = "backends/wasmi_runtime_layer" }
 wasm-bindgen-test = { version = "0.3" }
 wat = { version = "1.0" }
 

--- a/backends/wasmi_runtime_layer/Cargo.toml
+++ b/backends/wasmi_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi_runtime_layer"
-version = "0.41.0"
+version = "0.42.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
@@ -14,7 +14,7 @@ anyhow = { workspace = true }
 ref-cast = { workspace = true }
 smallvec = { workspace = true }
 wasm_runtime_layer = { workspace = true }
-wasmi = { version = "0.41", default-features = false }
+wasmi = { version = "0.42", default-features = false }
 
 [features]
 default = [ "std" ]


### PR DESCRIPTION
Just a version bump, depends on #41 being merged