### PR TITLE
Bump wasmi_runtime_layer to v0.45

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ std = [ "anyhow/std" ]
 
 [dev-dependencies]
 js_wasm_runtime_layer = { version = "0.4", path = "backends/js_wasm_runtime_layer" }
-wasmi_runtime_layer = { version = "0.44", path = "backends/wasmi_runtime_layer" }
+wasmi_runtime_layer = { version = "0.45", path = "backends/wasmi_runtime_layer" }
 wasm-bindgen-test = { version = "0.3" }
 wat = { version = "1.0" }
 

--- a/backends/wasmi_runtime_layer/Cargo.toml
+++ b/backends/wasmi_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi_runtime_layer"
-version = "0.44.0"
+version = "0.45.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
@@ -14,7 +14,7 @@ anyhow = { workspace = true }
 ref-cast = { workspace = true }
 smallvec = { workspace = true }
 wasm_runtime_layer = { workspace = true }
-wasmi = { version = "0.44", default-features = false }
+wasmi = { version = "0.45", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/backends/wasmi_runtime_layer/src/lib.rs
+++ b/backends/wasmi_runtime_layer/src/lib.rs
@@ -648,7 +648,6 @@ fn expect_memory32(x: u64) -> u32 {
 /// Convert a [`MemoryType`] to a [`wasmi::MemoryType`].
 fn memory_type_into(ty: MemoryType) -> wasmi::MemoryType {
     wasmi::MemoryType::new(ty.initial_pages(), ty.maximum_pages())
-        .expect("Could not convert memory.")
 }
 
 /// Convert a [`wasmi::TableType`] to a [`TableType`].


### PR DESCRIPTION
Blocked on breakage from https://github.com/wasmi-labs/wasmi/pull/1449, opened issue in https://github.com/wasmi-labs/wasmi/issues/1503.