### PR TITLE
Require T: 'static for Store, upgrade to wasmtime_runtime_layer v34.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ fxhash = { version = "0.2", default-features = false }
 hashbrown = { version = "0.15", default-features = false }
 ref-cast = { version = "1.0", default-features = false }
 smallvec = { version = "1.11", default-features = false }
-wasm_runtime_layer = { path = ".", version = "0.5", default-features = false }
+wasm_runtime_layer = { path = ".", version = "0.6", default-features = false }
 
 [workspace.package]
 edition = "2021"
@@ -22,7 +22,7 @@ repository = "https://github.com/DouglasDwyer/wasm_runtime_layer"
 
 [package]
 name = "wasm_runtime_layer"
-version = "0.5.0"
+version = "0.6.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
@@ -43,15 +43,15 @@ default = [ "std" ]
 std = [ "anyhow/std" ]
 
 [dev-dependencies]
-js_wasm_runtime_layer = { version = "0.5", path = "backends/js_wasm_runtime_layer" }
+js_wasm_runtime_layer = { version = "0.6", path = "backends/js_wasm_runtime_layer" }
 wasmi_runtime_layer = { version = "0.47", path = "backends/wasmi_runtime_layer" }
 wasm-bindgen-test = { version = "0.3" }
 wat = { version = "1.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 wasmer_runtime_layer = { version = "6.0", path = "backends/wasmer_runtime_layer" }
-wasmtime = { version = "33.0", default-features = false, features = [ "gc-null" ] }
-wasmtime_runtime_layer = { version = "33.0", path = "backends/wasmtime_runtime_layer" }
+wasmtime = { version = "34.0", default-features = false, features = [ "gc-null" ] }
+wasmtime_runtime_layer = { version = "34.0", path = "backends/wasmtime_runtime_layer" }
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/backends/js_wasm_runtime_layer/Cargo.toml
+++ b/backends/js_wasm_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "js_wasm_runtime_layer"
-version = "0.5.0"
+version = "0.6.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/backends/js_wasm_runtime_layer/src/func.rs
+++ b/backends/js_wasm_runtime_layer/src/func.rs
@@ -102,7 +102,7 @@ macro_rules! func_wrapper {
 }
 
 impl WasmFunc<Engine> for Func {
-    fn new<T>(
+    fn new<T: 'static>(
         mut ctx: impl AsContextMut<Engine, UserState = T>,
         ty: FuncType,
         func: impl 'static

--- a/backends/js_wasm_runtime_layer/src/lib.rs
+++ b/backends/js_wasm_runtime_layer/src/lib.rs
@@ -96,9 +96,9 @@ impl WasmEngine for Engine {
     type Instance = Instance;
     type Memory = Memory;
     type Module = Module;
-    type Store<T> = Store<T>;
-    type StoreContext<'a, T: 'a> = StoreContext<'a, T>;
-    type StoreContextMut<'a, T: 'a> = StoreContextMut<'a, T>;
+    type Store<T: 'static> = Store<T>;
+    type StoreContext<'a, T: 'static> = StoreContext<'a, T>;
+    type StoreContextMut<'a, T: 'static> = StoreContextMut<'a, T>;
     type Table = Table;
 }
 
@@ -332,7 +332,7 @@ impl WasmExternRef<Engine> for ExternRef {
         unimplemented!("ExternRef is not supported in the js_wasm_runtime_layer backend")
     }
 
-    fn downcast<'a, 's: 'a, T: 'static, S: 's>(
+    fn downcast<'a, 's: 'a, T: 'static, S: 'static>(
         &self,
         _: <Engine as WasmEngine>::StoreContext<'s, S>,
     ) -> anyhow::Result<&'a T> {

--- a/backends/wasmtime_runtime_layer/Cargo.toml
+++ b/backends/wasmtime_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime_runtime_layer"
-version = "33.0.0"
+version = "34.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
@@ -15,7 +15,7 @@ fxhash = { workspace = true }
 ref-cast = { workspace = true }
 smallvec = { workspace = true }
 wasm_runtime_layer = { workspace = true }
-wasmtime = { version = "33.0", default-features = false, features = [ "runtime", "gc" ] }
+wasmtime = { version = "34.0", default-features = false, features = [ "runtime", "gc" ] }
 
 [features]
 default = [ "cranelift", "std" ]

--- a/backends/wasmtime_runtime_layer/src/lib.rs
+++ b/backends/wasmtime_runtime_layer/src/lib.rs
@@ -43,13 +43,13 @@ type ArgumentVec<T> = SmallVec<[T; DEFAULT_ARGUMENT_SIZE]>;
 
 /// Generate the boilerplate delegation code for a newtype wrapper.
 macro_rules! delegate {
-    (#[derive($($derive:ident),*)] $newtype:ident($inner:ty) $($tt:tt)*) => {
+    (#[derive($($derive:ident),*)] $newtype:ident [$($gens:tt)*] ($inner:ty) $($impl:tt)*) => {
         #[derive($($derive,)* RefCast)]
         #[repr(transparent)]
         #[doc = concat!("Newtype wrapper around [`", stringify!($inner), "`].")]
-        pub struct $newtype$($tt)*($inner);
+        pub struct $newtype $($impl)* ($inner);
 
-        impl$($tt)* $newtype$($tt)* {
+        impl$($impl)* $newtype $($gens)* {
             #[must_use]
             #[doc = concat!(
                 "Create a [`wasm_runtime_layer::", stringify!($newtype), "`]-compatible `",
@@ -75,19 +75,19 @@ macro_rules! delegate {
             }
         }
 
-        impl$($tt)* From<$inner> for $newtype$($tt)* {
+        impl$($impl)* From<$inner> for $newtype $($gens)* {
             fn from(inner: $inner) -> Self {
                 Self::new(inner)
             }
         }
 
-        impl$($tt)* From<$newtype$($tt)*> for $inner {
-            fn from(wrapper: $newtype$($tt)*) -> Self {
+        impl$($impl)* From<$newtype $($gens)*> for $inner {
+            fn from(wrapper: $newtype $($gens)*) -> Self {
                 wrapper.into_inner()
             }
         }
 
-        impl$($tt)* Deref for $newtype$($tt)* {
+        impl$($impl)* Deref for $newtype $($gens)* {
             type Target = $inner;
 
             fn deref(&self) -> &Self::Target {
@@ -95,48 +95,48 @@ macro_rules! delegate {
             }
         }
 
-        impl$($tt)* DerefMut for $newtype$($tt)* {
+        impl$($impl)* DerefMut for $newtype $($gens)* {
             fn deref_mut(&mut self) -> &mut Self::Target {
                 &mut self.0
             }
         }
 
-        impl$($tt)* AsRef<$inner> for $newtype$($tt)* {
+        impl$($impl)* AsRef<$inner> for $newtype $($gens)* {
             fn as_ref(&self) -> &$inner {
                 &self.0
             }
         }
 
-        impl$($tt)* AsMut<$inner> for $newtype$($tt)* {
+        impl$($impl)* AsMut<$inner> for $newtype $($gens)* {
             fn as_mut(&mut self) -> &mut $inner {
                 &mut self.0
             }
         }
 
-        impl$($tt)* AsRef<$newtype$($tt)*> for $inner {
-            fn as_ref(&self) -> &$newtype$($tt)* {
+        impl$($impl)* AsRef<$newtype $($gens)*> for $inner {
+            fn as_ref(&self) -> &$newtype $($gens)* {
                 $newtype::ref_cast(self)
             }
         }
 
-        impl$($tt)* AsMut<$newtype$($tt)*> for $inner {
-            fn as_mut(&mut self) -> &mut $newtype$($tt)* {
+        impl$($impl)* AsMut<$newtype $($gens)*> for $inner {
+            fn as_mut(&mut self) -> &mut $newtype $($gens)* {
                 $newtype::ref_cast_mut(self)
             }
         }
     }
 }
 
-delegate! { #[derive(Clone, Default)] Engine(wasmtime::Engine) }
-delegate! { #[derive(Clone)] ExternRef(wasmtime::Rooted<wasmtime::ExternRef>) }
-delegate! { #[derive(Clone)] Func(wasmtime::Func) }
-delegate! { #[derive(Clone)] Global(wasmtime::Global) }
-delegate! { #[derive(Clone)] Memory(wasmtime::Memory) }
-delegate! { #[derive(Clone)] Module(wasmtime::Module) }
-delegate! { #[derive()] Store(wasmtime::Store<T>) <T> }
-delegate! { #[derive()] StoreContext(wasmtime::StoreContext<'a, T>) <'a, T> }
-delegate! { #[derive()] StoreContextMut(wasmtime::StoreContextMut<'a, T>) <'a, T> }
-delegate! { #[derive(Clone)] Table(wasmtime::Table) }
+delegate! { #[derive(Clone, Default)] Engine[](wasmtime::Engine) }
+delegate! { #[derive(Clone)] ExternRef[](wasmtime::Rooted<wasmtime::ExternRef>) }
+delegate! { #[derive(Clone)] Func[](wasmtime::Func) }
+delegate! { #[derive(Clone)] Global[](wasmtime::Global) }
+delegate! { #[derive(Clone)] Memory[](wasmtime::Memory) }
+delegate! { #[derive(Clone)] Module[](wasmtime::Module) }
+delegate! { #[derive()] Store[<T>](wasmtime::Store<T>) <T: 'static> }
+delegate! { #[derive()] StoreContext[<'a, T>](wasmtime::StoreContext<'a, T>) <'a, T: 'static> }
+delegate! { #[derive()] StoreContextMut[<'a, T>](wasmtime::StoreContextMut<'a, T>) <'a, T: 'static> }
+delegate! { #[derive(Clone)] Table[](wasmtime::Table) }
 
 impl WasmEngine for Engine {
     type ExternRef = ExternRef;
@@ -145,9 +145,9 @@ impl WasmEngine for Engine {
     type Instance = Instance;
     type Memory = Memory;
     type Module = Module;
-    type Store<T> = Store<T>;
-    type StoreContext<'a, T: 'a> = StoreContext<'a, T>;
-    type StoreContextMut<'a, T: 'a> = StoreContextMut<'a, T>;
+    type Store<T: 'static> = Store<T>;
+    type StoreContext<'a, T: 'static> = StoreContext<'a, T>;
+    type StoreContextMut<'a, T: 'static> = StoreContextMut<'a, T>;
     type Table = Table;
 }
 
@@ -159,7 +159,7 @@ impl WasmExternRef<Engine> for ExternRef {
         )
     }
 
-    fn downcast<'a, 's: 'a, T: 'static, S: 's>(
+    fn downcast<'a, 's: 'a, T: 'static, S: 'static>(
         &'a self,
         ctx: StoreContext<'s, S>,
     ) -> Result<&'a T> {
@@ -171,7 +171,7 @@ impl WasmExternRef<Engine> for ExternRef {
 }
 
 impl WasmFunc<Engine> for Func {
-    fn new<T>(
+    fn new<T: 'static>(
         mut ctx: impl AsContextMut<Engine, UserState = T>,
         ty: FuncType,
         func: impl 'static
@@ -426,7 +426,7 @@ impl WasmModule<Engine> for Module {
     }
 }
 
-impl<T> WasmStore<T, Engine> for Store<T> {
+impl<T: 'static> WasmStore<T, Engine> for Store<T> {
     fn new(engine: &Engine, data: T) -> Self {
         Self::new(wasmtime::Store::new(engine, data))
     }
@@ -448,7 +448,7 @@ impl<T> WasmStore<T, Engine> for Store<T> {
     }
 }
 
-impl<T> AsContext<Engine> for Store<T> {
+impl<T: 'static> AsContext<Engine> for Store<T> {
     type UserState = T;
 
     fn as_context(&self) -> StoreContext<'_, Self::UserState> {
@@ -456,13 +456,13 @@ impl<T> AsContext<Engine> for Store<T> {
     }
 }
 
-impl<T> AsContextMut<Engine> for Store<T> {
+impl<T: 'static> AsContextMut<Engine> for Store<T> {
     fn as_context_mut(&mut self) -> StoreContextMut<'_, Self::UserState> {
         StoreContextMut::new(wasmtime::AsContextMut::as_context_mut(self.as_mut()))
     }
 }
 
-impl<'a, T> WasmStoreContext<'a, T, Engine> for StoreContext<'a, T> {
+impl<'a, T: 'static> WasmStoreContext<'a, T, Engine> for StoreContext<'a, T> {
     fn engine(&self) -> &Engine {
         Engine::ref_cast(self.as_ref().engine())
     }
@@ -472,7 +472,7 @@ impl<'a, T> WasmStoreContext<'a, T, Engine> for StoreContext<'a, T> {
     }
 }
 
-impl<T> AsContext<Engine> for StoreContext<'_, T> {
+impl<T: 'static> AsContext<Engine> for StoreContext<'_, T> {
     type UserState = T;
 
     fn as_context(&self) -> StoreContext<T> {
@@ -480,7 +480,7 @@ impl<T> AsContext<Engine> for StoreContext<'_, T> {
     }
 }
 
-impl<T> AsContext<Engine> for StoreContextMut<'_, T> {
+impl<T: 'static> AsContext<Engine> for StoreContextMut<'_, T> {
     type UserState = T;
 
     fn as_context(&self) -> StoreContext<T> {
@@ -488,13 +488,13 @@ impl<T> AsContext<Engine> for StoreContextMut<'_, T> {
     }
 }
 
-impl<T> AsContextMut<Engine> for StoreContextMut<'_, T> {
+impl<T: 'static> AsContextMut<Engine> for StoreContextMut<'_, T> {
     fn as_context_mut(&mut self) -> StoreContextMut<T> {
         StoreContextMut::new(wasmtime::AsContextMut::as_context_mut(self.as_mut()))
     }
 }
 
-impl<'a, T> WasmStoreContext<'a, T, Engine> for StoreContextMut<'a, T> {
+impl<'a, T: 'static> WasmStoreContext<'a, T, Engine> for StoreContextMut<'a, T> {
     fn engine(&self) -> &Engine {
         Engine::ref_cast(self.as_ref().engine())
     }
@@ -504,7 +504,7 @@ impl<'a, T> WasmStoreContext<'a, T, Engine> for StoreContextMut<'a, T> {
     }
 }
 
-impl<'a, T> WasmStoreContextMut<'a, T, Engine> for StoreContextMut<'a, T> {
+impl<'a, T: 'static> WasmStoreContextMut<'a, T, Engine> for StoreContextMut<'a, T> {
     fn data_mut(&mut self) -> &mut T {
         self.as_mut().data_mut()
     }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -342,11 +342,11 @@ pub trait WasmEngine: 'static + Clone + Sized {
     /// The module type.
     type Module: WasmModule<Self>;
     /// The store type.
-    type Store<T>: WasmStore<T, Self>;
+    type Store<T: 'static>: WasmStore<T, Self>;
     /// The store context type.
-    type StoreContext<'a, T: 'a>: WasmStoreContext<'a, T, Self>;
+    type StoreContext<'a, T: 'static>: WasmStoreContext<'a, T, Self>;
     /// The mutable store context type.
-    type StoreContextMut<'a, T: 'a>: WasmStoreContextMut<'a, T, Self>;
+    type StoreContextMut<'a, T: 'static>: WasmStoreContextMut<'a, T, Self>;
     /// The table type.
     type Table: WasmTable<Self>;
 }
@@ -356,7 +356,7 @@ pub trait WasmExternRef<E: WasmEngine>: Clone + Sized + Send + Sync {
     /// Creates a new reference wrapping the given value.
     fn new<T: 'static + Send + Sync>(ctx: impl AsContextMut<E>, object: T) -> Self;
     /// Returns a shared reference to the underlying data.
-    fn downcast<'a, 's: 'a, T: 'static, S: 's>(
+    fn downcast<'a, 's: 'a, T: 'static, S: 'static>(
         &'a self,
         store: E::StoreContext<'s, S>,
     ) -> Result<&'a T>;
@@ -365,7 +365,7 @@ pub trait WasmExternRef<E: WasmEngine>: Clone + Sized + Send + Sync {
 /// Provides a Wasm or host function reference.
 pub trait WasmFunc<E: WasmEngine>: Clone + Sized + Send + Sync {
     /// Creates a new function with the given arguments.
-    fn new<T>(
+    fn new<T: 'static>(
         ctx: impl AsContextMut<E, UserState = T>,
         ty: FuncType,
         func: impl 'static
@@ -453,7 +453,7 @@ pub trait WasmModule<E: WasmEngine>: Clone + Sized + Send + Sync {
 }
 
 /// Provides all of the global state that can be manipulated by WASM programs.
-pub trait WasmStore<T, E: WasmEngine>:
+pub trait WasmStore<T: 'static, E: WasmEngine>:
     AsContext<E, UserState = T> + AsContextMut<E, UserState = T>
 {
     /// Creates a new store atop the given engine.
@@ -469,7 +469,7 @@ pub trait WasmStore<T, E: WasmEngine>:
 }
 
 /// Provides a temporary immutable handle to a store.
-pub trait WasmStoreContext<'a, T, E: WasmEngine>: AsContext<E, UserState = T> {
+pub trait WasmStoreContext<'a, T: 'static, E: WasmEngine>: AsContext<E, UserState = T> {
     /// Gets the engine associated with this store.
     fn engine(&self) -> &E;
     /// Gets an immutable reference to the underlying stored data.
@@ -477,7 +477,7 @@ pub trait WasmStoreContext<'a, T, E: WasmEngine>: AsContext<E, UserState = T> {
 }
 
 /// Provides a temporary mutable handle to a store.
-pub trait WasmStoreContextMut<'a, T, E: WasmEngine>:
+pub trait WasmStoreContextMut<'a, T: 'static, E: WasmEngine>:
     WasmStoreContext<'a, T, E> + AsContextMut<E, UserState = T>
 {
     /// Gets a mutable reference to the underlying stored data.
@@ -487,7 +487,7 @@ pub trait WasmStoreContextMut<'a, T, E: WasmEngine>:
 /// A trait used to get shared access to a store.
 pub trait AsContext<E: WasmEngine> {
     /// The type of data associated with the store.
-    type UserState;
+    type UserState: 'static;
 
     /// Returns the store context that this type provides access to.
     fn as_context(&self) -> E::StoreContext<'_, Self::UserState>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,12 +731,12 @@ impl<E: WasmEngine> Engine<E> {
 /// the Wasm bytes into a valid module artifact).
 ///
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#store>
-pub struct Store<T, E: WasmEngine> {
+pub struct Store<T: 'static, E: WasmEngine> {
     /// The backing implementation.
     inner: E::Store<T>,
 }
 
-impl<T, E: WasmEngine> Store<T, E> {
+impl<T: 'static, E: WasmEngine> Store<T, E> {
     /// Creates a new [`Store`] with a specific [`Engine`].
     pub fn new(engine: &Engine<E>, data: T) -> Self {
         Self {
@@ -769,12 +769,12 @@ impl<T, E: WasmEngine> Store<T, E> {
 ///
 /// This type is suitable for [`AsContext`] trait bounds on methods if desired.
 /// For more information, see [`Store`].
-pub struct StoreContext<'a, T: 'a, E: WasmEngine> {
+pub struct StoreContext<'a, T: 'static, E: WasmEngine> {
     /// The backing implementation.
     inner: E::StoreContext<'a, T>,
 }
 
-impl<'a, T: 'a, E: WasmEngine> StoreContext<'a, T, E> {
+impl<'a, T: 'static, E: WasmEngine> StoreContext<'a, T, E> {
     /// Returns the underlying [`Engine`] this store is connected to.
     pub fn engine(&self) -> &Engine<E> {
         Engine::<E>::ref_cast(self.inner.engine())
@@ -792,12 +792,12 @@ impl<'a, T: 'a, E: WasmEngine> StoreContext<'a, T, E> {
 ///
 /// This type is suitable for [`AsContextMut`] or [`AsContext`] trait bounds on methods if desired.
 /// For more information, see [`Store`].
-pub struct StoreContextMut<'a, T: 'a, E: WasmEngine> {
+pub struct StoreContextMut<'a, T: 'static, E: WasmEngine> {
     /// The backing implementation.
     pub inner: E::StoreContextMut<'a, T>,
 }
 
-impl<'a, T: 'a, E: WasmEngine> StoreContextMut<'a, T, E> {
+impl<'a, T: 'static, E: WasmEngine> StoreContextMut<'a, T, E> {
     /// Returns the underlying [`Engine`] this store is connected to.
     pub fn engine(&self) -> &Engine<E> {
         Engine::<E>::ref_cast(self.inner.engine())
@@ -927,7 +927,7 @@ impl ExternRef {
     }
 
     /// Returns a shared reference to the underlying data for this [`ExternRef`].
-    pub fn downcast<'a, 's: 'a, T: 'static, S: 's, E: WasmEngine>(
+    pub fn downcast<'a, 's: 'a, T: 'static, S: 'static, E: WasmEngine>(
         &'a self,
         ctx: StoreContext<'s, S, E>,
     ) -> Result<&'a T> {
@@ -1329,7 +1329,7 @@ pub trait AsContext {
     type Engine: WasmEngine;
 
     /// The user state associated with the [`Store`], aka the `T` in `Store<T>`.
-    type UserState;
+    type UserState: 'static;
 
     /// Returns the store context that this type provides access to.
     fn as_context(&self) -> StoreContext<Self::UserState, Self::Engine>;
@@ -1341,7 +1341,7 @@ pub trait AsContextMut: AsContext {
     fn as_context_mut(&mut self) -> StoreContextMut<Self::UserState, Self::Engine>;
 }
 
-impl<T, E: WasmEngine> AsContext for Store<T, E> {
+impl<T: 'static, E: WasmEngine> AsContext for Store<T, E> {
     type Engine = E;
 
     type UserState = T;
@@ -1353,7 +1353,7 @@ impl<T, E: WasmEngine> AsContext for Store<T, E> {
     }
 }
 
-impl<T, E: WasmEngine> AsContextMut for Store<T, E> {
+impl<T: 'static, E: WasmEngine> AsContextMut for Store<T, E> {
     fn as_context_mut(&mut self) -> StoreContextMut<Self::UserState, Self::Engine> {
         StoreContextMut {
             inner: crate::backend::AsContextMut::as_context_mut(&mut self.inner),
@@ -1387,7 +1387,7 @@ impl<T: AsContextMut> AsContextMut for &mut T {
     }
 }
 
-impl<'a, T: 'a, E: WasmEngine> AsContext for StoreContext<'a, T, E> {
+impl<'a, T: 'static, E: WasmEngine> AsContext for StoreContext<'a, T, E> {
     type Engine = E;
 
     type UserState = T;
@@ -1399,7 +1399,7 @@ impl<'a, T: 'a, E: WasmEngine> AsContext for StoreContext<'a, T, E> {
     }
 }
 
-impl<'a, T: 'a, E: WasmEngine> AsContext for StoreContextMut<'a, T, E> {
+impl<'a, T: 'static, E: WasmEngine> AsContext for StoreContextMut<'a, T, E> {
     type Engine = E;
 
     type UserState = T;
@@ -1411,7 +1411,7 @@ impl<'a, T: 'a, E: WasmEngine> AsContext for StoreContextMut<'a, T, E> {
     }
 }
 
-impl<'a, T: 'a, E: WasmEngine> AsContextMut for StoreContextMut<'a, T, E> {
+impl<'a, T: 'static, E: WasmEngine> AsContextMut for StoreContextMut<'a, T, E> {
     fn as_context_mut(&mut self) -> StoreContextMut<Self::UserState, Self::Engine> {
         StoreContextMut {
             inner: crate::backend::AsContextMut::as_context_mut(&mut self.inner),


### PR DESCRIPTION
With https://github.com/bytecodealliance/wasmtime/pull/10760, wasmtime now requires `T: 'static` for store. While we advocated to not have the bound in wasmi, it now seems like the ship has sailed and we have to adapt.

@alexcrichton Since you also tried to avoid a static bound for as long as possible, do you think it makes sense for our abstraction over several WASM runtimes to adopt the bound?

@Robbepop If we go forward here, it means you can bring back the static bound in wasmi as well - thank you for removing it a few versions ago to help our downstream crate, now the momentum is in favour of your original change.

@DouglasDwyer This will require a major release for wasm_runtime_layer (and wasm_component_layer). I've prepared updates for wasmtime_runtime_layer and js_wasm_runtime_layer in this PR, I think for wasmi and wasmer we just wait until their next release.