### PR TITLE
Bump wasmtime_runtime_layer to v37.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ wat = { version = "1.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 # wasmer_runtime_layer = { version = "6.0", path = "backends/wasmer_runtime_layer" }
-wasmtime = { version = "36.0", default-features = false, features = [ "gc-null" ] }
-wasmtime_runtime_layer = { version = "36.0", path = "backends/wasmtime_runtime_layer" }
+wasmtime = { version = "37.0", default-features = false, features = [ "gc-null" ] }
+wasmtime_runtime_layer = { version = "37.0", path = "backends/wasmtime_runtime_layer" }
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/backends/wasmtime_runtime_layer/Cargo.toml
+++ b/backends/wasmtime_runtime_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime_runtime_layer"
-version = "36.0.0"
+version = "37.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
@@ -15,7 +15,7 @@ fxhash = { workspace = true }
 ref-cast = { workspace = true }
 smallvec = { workspace = true }
 wasm_runtime_layer = { workspace = true }
-wasmtime = { version = "36.0", default-features = false, features = [ "runtime", "gc" ] }
+wasmtime = { version = "37.0", default-features = false, features = [ "runtime", "gc" ] }
 
 [features]
 default = [ "cranelift", "std" ]

--- a/backends/wasmtime_runtime_layer/src/lib.rs
+++ b/backends/wasmtime_runtime_layer/src/lib.rs
@@ -576,6 +576,9 @@ fn value_from(value: wasmtime::Val) -> Value<Engine> {
         wasmtime::Val::ExnRef(_) => {
             unimplemented!("exnref is not supported in the wasm_runtime_layer")
         }
+        wasmtime::Val::ContRef(_) => {
+            unimplemented!("contref is not supported in the wasm_runtime_layer")
+        }
     }
 }
 


### PR DESCRIPTION
Mostly a version bump but also adds a match case for wasmtime's newly added continuation reference support