### PR TITLE
fix: replace unwrap with expect with meaningful messages

### DIFF
--- a/backends/js_wasm_runtime_layer/src/instance.rs
+++ b/backends/js_wasm_runtime_layer/src/instance.rs
@@ -131,13 +131,13 @@ fn create_imports_object<T>(store: &StoreInner<T>, imports: &Imports<Engine>) ->
             let obj = Object::new();
 
             for (name, value) in imports {
-                Reflect::set(&obj, name, value).unwrap();
+                Reflect::set(&obj, name, value).expect("js operation failed");
             }
 
             (module, obj)
         })
         .fold(Object::new(), |acc, (m, imports)| {
-            Reflect::set(&acc, &(m).into(), &imports).unwrap();
+            Reflect::set(&acc, &(m).into(), &imports).expect("js operation failed");
             acc
         });
 
@@ -165,11 +165,11 @@ fn process_exports<T>(
         .into_iter()
         .map(|entry| {
             let name = Reflect::get_u32(&entry, 0)
-                .unwrap()
+                .expect("js operation failed")
                 .as_string()
                 .expect("name is string");
 
-            let value: JsValue = Reflect::get_u32(&entry, 1).unwrap();
+            let value: JsValue = Reflect::get_u32(&entry, 1).expect("js operation failed");
 
             #[cfg(feature = "tracing")]
             let _span = tracing::trace_span!("process_export", ?name, ?value).entered();
@@ -185,9 +185,9 @@ fn process_exports<T>(
                     let func = Func::from_exported_function(
                         store,
                         value,
-                        signature.try_into_func().unwrap(),
+                        signature.try_into_func().expect("js operation failed"),
                     )
-                    .unwrap();
+                    .expect("js operation failed");
 
                     Extern::Func(func)
                 }
@@ -196,36 +196,36 @@ fn process_exports<T>(
                         let func = Func::from_exported_function(
                             store,
                             value,
-                            signature.try_into_func().unwrap(),
+                            signature.try_into_func().expect("js operation failed"),
                         )
-                        .unwrap();
+                        .expect("js operation failed");
 
                         Extern::Func(func)
                     } else if value.is_instance_of::<WebAssembly::Table>() {
                         let table = Table::from_stored_js(
                             store,
                             value,
-                            signature.try_into_table().unwrap(),
+                            signature.try_into_table().expect("js operation failed"),
                         )
-                        .unwrap();
+                        .expect("js operation failed");
 
                         Extern::Table(table)
                     } else if value.is_instance_of::<WebAssembly::Memory>() {
                         let memory = Memory::from_exported_memory(
                             store,
                             value,
-                            signature.try_into_memory().unwrap(),
+                            signature.try_into_memory().expect("js operation failed"),
                         )
-                        .unwrap();
+                        .expect("js operation failed");
 
                         Extern::Memory(memory)
                     } else if value.is_instance_of::<WebAssembly::Global>() {
                         let global = Global::from_exported_global(
                             store,
                             value,
-                            signature.try_into_global().unwrap(),
+                            signature.try_into_global().expect("js operation failed"),
                         )
-                        .unwrap();
+                        .expect("js operation failed");
 
                         Extern::Global(global)
                     } else {

--- a/backends/js_wasm_runtime_layer/src/lib.rs
+++ b/backends/js_wasm_runtime_layer/src/lib.rs
@@ -221,13 +221,13 @@ impl WasmGlobal<Engine> for Global {
 
         let desc = Object::new();
 
-        Reflect::set(&desc, &"value".into(), &value.ty().to_js()).unwrap();
-        Reflect::set(&desc, &"mutable".into(), &mutable.into()).unwrap();
+        Reflect::set(&desc, &"value".into(), &value.ty().to_js()).expect("js operation failed");
+        Reflect::set(&desc, &"mutable".into(), &mutable.into()).expect("js operation failed");
 
-        let value = value.to_stored_js(&ctx).unwrap();
+        let value = value.to_stored_js(&ctx).expect("js operation failed");
 
         let global = GlobalInner {
-            value: WebAssembly::Global::new(&desc, &value).unwrap(),
+            value: WebAssembly::Global::new(&desc, &value).expect("js operation failed"),
             ty,
         };
 
@@ -261,7 +261,7 @@ impl WasmGlobal<Engine> for Global {
         let ty = inner.ty;
         let value = inner.value.value();
 
-        value_from_js_typed(store, &ty.content(), value).unwrap()
+        value_from_js_typed(store, &ty.content(), value).expect("js operation failed")
     }
 }
 

--- a/backends/js_wasm_runtime_layer/src/memory.rs
+++ b/backends/js_wasm_runtime_layer/src/memory.rs
@@ -28,7 +28,7 @@ impl MemoryInner {
     /// Returns a `Uint8Array` view of the memory
     pub(crate) fn as_uint8array(&self, offset: u32, len: u32) -> Uint8Array {
         let buffer = self.value.buffer();
-        let buffer = buffer.dyn_ref::<ArrayBuffer>().unwrap();
+        let buffer = buffer.dyn_ref::<ArrayBuffer>().expect("js operation failed");
 
         Uint8Array::new_with_byte_offset_and_length(buffer, offset, len)
     }
@@ -61,9 +61,9 @@ impl Memory {
 impl WasmMemory<Engine> for Memory {
     fn new(mut ctx: impl AsContextMut<Engine>, ty: MemoryType) -> Result<Self> {
         let desc = Object::new();
-        Reflect::set(&desc, &"initial".into(), &ty.initial_pages().into()).unwrap();
+        Reflect::set(&desc, &"initial".into(), &ty.initial_pages().into()).expect("js operation failed");
         if let Some(maximum) = ty.maximum_pages() {
-            Reflect::set(&desc, &"maximum".into(), &maximum.into()).unwrap();
+            Reflect::set(&desc, &"maximum".into(), &maximum.into()).expect("js operation failed");
         }
 
         let memory = WebAssembly::Memory::new(&desc).map_err(JsErrorMsg::from)?;

--- a/backends/js_wasm_runtime_layer/src/table.rs
+++ b/backends/js_wasm_runtime_layer/src/table.rs
@@ -73,11 +73,11 @@ impl WasmTable<Engine> for Table {
         let mut ctx: StoreContextMut<_> = ctx.as_context_mut();
 
         let desc = Object::new();
-        Reflect::set(&desc, &"element".into(), &ty.element().to_js()).unwrap();
+        Reflect::set(&desc, &"element".into(), &ty.element().to_js()).expect("js operation failed");
 
-        Reflect::set(&desc, &"initial".into(), &ty.minimum().into()).unwrap();
+        Reflect::set(&desc, &"initial".into(), &ty.minimum().into()).expect("js operation failed");
         if let Some(max) = ty.maximum() {
-            Reflect::set(&desc, &"initial".into(), &max.into()).unwrap();
+            Reflect::set(&desc, &"initial".into(), &max.into()).expect("js operation failed");
         }
 
         let table = WebAssembly::Table::new_with_value(&desc, init.to_stored_js(&ctx)?)
@@ -119,7 +119,7 @@ impl WasmTable<Engine> for Table {
         let old_len = inner.table.grow(delta).map_err(JsErrorMsg::from)?;
 
         for i in old_len..(old_len + delta) {
-            inner.table.set(i, init).unwrap();
+            inner.table.set(i, init).expect("js operation failed");
         }
 
         Ok(old_len)

--- a/backends/wasmer_runtime_layer/src/lib.rs
+++ b/backends/wasmer_runtime_layer/src/lib.rs
@@ -249,7 +249,7 @@ impl WasmFunc<Engine> for Func {
     }
 
     fn ty(&self, ctx: impl AsContext<Engine>) -> FuncType {
-        func_type_from(self.as_ref().ty(ctx.as_context().as_store_ref())).unwrap()
+        func_type_from(self.as_ref().ty(ctx.as_context().as_store_ref())).expect("failed to convert type")
     }
 
     fn call<T>(
@@ -289,7 +289,7 @@ impl WasmGlobal<Engine> for Global {
     }
 
     fn ty(&self, ctx: impl AsContext<Engine>) -> GlobalType {
-        global_type_from(self.as_ref().ty(ctx.as_context().as_store_ref())).unwrap()
+        global_type_from(self.as_ref().ty(ctx.as_context().as_store_ref())).expect("failed to convert type")
     }
 
     fn set(&self, mut ctx: impl AsContextMut<Engine>, new_value: Val<Engine>) -> Result<()> {
@@ -299,7 +299,7 @@ impl WasmGlobal<Engine> for Global {
     }
 
     fn get(&self, mut ctx: impl AsContextMut<Engine>) -> Val<Engine> {
-        value_from(self.as_ref().get(ctx.as_context_mut().as_store_mut())).unwrap()
+        value_from(self.as_ref().get(ctx.as_context_mut().as_store_mut())).expect("failed to convert type")
     }
 }
 
@@ -331,7 +331,7 @@ impl WasmInstance<Engine> for Instance {
                 .iter()
                 .map(|(n, e)| Export {
                     name: n.clone(),
-                    value: extern_from(e.clone()).unwrap(),
+                    value: extern_from(e.clone()).expect("failed to convert type"),
                 })
                 .collect::<Vec<_>>()
                 .into_iter(),
@@ -344,7 +344,7 @@ impl WasmInstance<Engine> for Instance {
             .get_extern(name)
             .map(|e| extern_from(e.clone()))
             .transpose()
-            .unwrap()
+            .expect("failed to convert type")
     }
 }
 
@@ -431,21 +431,21 @@ impl WasmModule<Engine> for Module {
     fn exports(&self) -> Box<dyn '_ + Iterator<Item = ExportType<'_>>> {
         Box::new(self.exports.values().map(|x| ExportType {
             name: x.name(),
-            ty: extern_type_from(x.ty().clone()).unwrap(),
+            ty: extern_type_from(x.ty().clone()).expect("failed to convert type"),
         }))
     }
 
     fn get_export(&self, name: &str) -> Option<ExternType> {
         self.exports
             .get(name)
-            .map(|e| extern_type_from(e.ty().clone()).unwrap())
+            .map(|e| extern_type_from(e.ty().clone()).expect("failed to convert type"))
     }
 
     fn imports(&self) -> Box<dyn '_ + Iterator<Item = ImportType<'_>>> {
         Box::new(self.imports.iter().map(|x| ImportType {
             module: x.module(),
             name: x.name(),
-            ty: extern_type_from(x.ty().clone()).unwrap(),
+            ty: extern_type_from(x.ty().clone()).expect("failed to convert type"),
         }))
     }
 }
@@ -635,7 +635,7 @@ impl WasmTable<Engine> for Table {
     }
 
     fn ty(&self, ctx: impl AsContext<Engine>) -> TableType {
-        table_type_from(self.as_ref().ty(ctx.as_context().as_store_ref())).unwrap()
+        table_type_from(self.as_ref().ty(ctx.as_context().as_store_ref())).expect("failed to convert type")
     }
 
     fn size(&self, ctx: impl AsContext<Engine>) -> u32 {
@@ -662,7 +662,7 @@ impl WasmTable<Engine> for Table {
             .get(ctx.as_context_mut().as_store_mut(), index)
             .map(ref_from_value)
             .transpose()
-            .unwrap()
+            .expect("failed to convert type")
     }
 
     fn set(&self, mut ctx: impl AsContextMut<Engine>, index: u32, elem: Ref<Engine>) -> Result<()> {

--- a/backends/wasmi_runtime_layer/src/lib.rs
+++ b/backends/wasmi_runtime_layer/src/lib.rs
@@ -316,7 +316,7 @@ impl WasmMemory<Engine> for Memory {
     }
 
     fn ty(&self, ctx: impl AsContext<Engine>) -> MemoryType {
-        memory_type_from(self.as_ref().ty(ctx.as_context().into_inner())).unwrap()
+        memory_type_from(self.as_ref().ty(ctx.as_context().into_inner())).expect("failed to convert type")
     }
 
     fn grow(&self, mut ctx: impl AsContextMut<Engine>, additional: u32) -> Result<u32> {
@@ -327,7 +327,7 @@ impl WasmMemory<Engine> for Memory {
     }
 
     fn current_pages(&self, ctx: impl AsContext<Engine>) -> u32 {
-        expect_memory32(self.as_ref().size(ctx.as_context().into_inner())).unwrap()
+        expect_memory32(self.as_ref().size(ctx.as_context().into_inner())).expect("failed to convert type")
     }
 
     fn read(&self, ctx: impl AsContext<Engine>, offset: usize, buffer: &mut [u8]) -> Result<()> {
@@ -366,7 +366,7 @@ impl WasmModule<Engine> for Module {
     fn exports(&self) -> Box<dyn '_ + Iterator<Item = ExportType<'_>>> {
         Box::new(self.as_ref().exports().map(|x| ExportType {
             name: x.name(),
-            ty: extern_type_from(x.ty().clone()).unwrap(),
+            ty: extern_type_from(x.ty().clone()).expect("failed to convert type"),
         }))
     }
 
@@ -375,14 +375,14 @@ impl WasmModule<Engine> for Module {
             .get_export(name)
             .map(extern_type_from)
             .transpose()
-            .unwrap()
+            .expect("failed to convert type")
     }
 
     fn imports(&self) -> Box<dyn '_ + Iterator<Item = ImportType<'_>>> {
         Box::new(self.as_ref().imports().map(|x| ImportType {
             module: x.module(),
             name: x.name(),
-            ty: extern_type_from(x.ty().clone()).unwrap(),
+            ty: extern_type_from(x.ty().clone()).expect("failed to convert type"),
         }))
     }
 }
@@ -483,11 +483,11 @@ impl WasmTable<Engine> for Table {
     }
 
     fn ty(&self, ctx: impl AsContext<Engine>) -> TableType {
-        table_type_from(self.as_ref().ty(ctx.as_context().into_inner())).unwrap()
+        table_type_from(self.as_ref().ty(ctx.as_context().into_inner())).expect("failed to convert type")
     }
 
     fn size(&self, ctx: impl AsContext<Engine>) -> u32 {
-        expect_table32(self.as_ref().size(ctx.as_context().into_inner())).unwrap()
+        expect_table32(self.as_ref().size(ctx.as_context().into_inner())).expect("failed to convert type")
     }
 
     fn grow(

--- a/backends/wasmtime_runtime_layer/src/lib.rs
+++ b/backends/wasmtime_runtime_layer/src/lib.rs
@@ -215,7 +215,7 @@ impl WasmFunc<Engine> for Func {
     }
 
     fn ty(&self, ctx: impl AsContext<Engine>) -> FuncType {
-        func_type_from(self.as_ref().ty(ctx.as_context().into_inner())).unwrap()
+        func_type_from(self.as_ref().ty(ctx.as_context().into_inner())).expect("failed to convert type")
     }
 
     fn call<T>(
@@ -266,7 +266,7 @@ impl WasmGlobal<Engine> for Global {
     }
 
     fn ty(&self, ctx: impl AsContext<Engine>) -> GlobalType {
-        global_type_from(self.as_ref().ty(ctx.as_context().into_inner())).unwrap()
+        global_type_from(self.as_ref().ty(ctx.as_context().into_inner())).expect("failed to convert type")
     }
 
     fn set(&self, mut ctx: impl AsContextMut<Engine>, new_value: Val<Engine>) -> Result<()> {
@@ -276,7 +276,7 @@ impl WasmGlobal<Engine> for Global {
     }
 
     fn get(&self, mut ctx: impl AsContextMut<Engine>) -> Val<Engine> {
-        value_from(self.as_ref().get(ctx.as_context_mut().into_inner())).unwrap()
+        value_from(self.as_ref().get(ctx.as_context_mut().into_inner())).expect("failed to convert type")
     }
 }
 
@@ -379,7 +379,7 @@ impl WasmMemory<Engine> for Memory {
     }
 
     fn ty(&self, ctx: impl AsContext<Engine>) -> MemoryType {
-        memory_type_from(self.as_ref().ty(ctx.as_context().into_inner())).unwrap()
+        memory_type_from(self.as_ref().ty(ctx.as_context().into_inner())).expect("failed to convert type")
     }
 
     fn grow(&self, mut ctx: impl AsContextMut<Engine>, additional: u32) -> Result<u32> {
@@ -390,7 +390,7 @@ impl WasmMemory<Engine> for Memory {
     }
 
     fn current_pages(&self, ctx: impl AsContext<Engine>) -> u32 {
-        expect_memory32(self.as_ref().size(ctx.as_context().into_inner())).unwrap()
+        expect_memory32(self.as_ref().size(ctx.as_context().into_inner())).expect("failed to convert type")
     }
 
     fn read(&self, ctx: impl AsContext<Engine>, offset: usize, buffer: &mut [u8]) -> Result<()> {
@@ -429,7 +429,7 @@ impl WasmModule<Engine> for Module {
     fn exports(&self) -> Box<dyn '_ + Iterator<Item = ExportType<'_>>> {
         Box::new(self.as_ref().exports().map(|x| ExportType {
             name: x.name(),
-            ty: extern_type_from(x.ty()).unwrap(),
+            ty: extern_type_from(x.ty()).expect("failed to convert type"),
         }))
     }
 
@@ -438,14 +438,14 @@ impl WasmModule<Engine> for Module {
             .get_export(name)
             .map(extern_type_from)
             .transpose()
-            .unwrap()
+            .expect("failed to convert type")
     }
 
     fn imports(&self) -> Box<dyn '_ + Iterator<Item = ImportType<'_>>> {
         Box::new(self.as_ref().imports().map(|x| ImportType {
             module: x.module(),
             name: x.name(),
-            ty: extern_type_from(x.ty()).unwrap(),
+            ty: extern_type_from(x.ty()).expect("failed to convert type"),
         }))
     }
 }
@@ -544,11 +544,11 @@ impl WasmTable<Engine> for Table {
     }
 
     fn ty(&self, ctx: impl AsContext<Engine>) -> TableType {
-        table_type_from(self.as_ref().ty(ctx.as_context().into_inner())).unwrap()
+        table_type_from(self.as_ref().ty(ctx.as_context().into_inner())).expect("failed to convert type")
     }
 
     fn size(&self, ctx: impl AsContext<Engine>) -> u32 {
-        expect_table32(self.as_ref().size(ctx.as_context().into_inner())).unwrap()
+        expect_table32(self.as_ref().size(ctx.as_context().into_inner())).expect("failed to convert type")
     }
 
     fn grow(
@@ -572,7 +572,7 @@ impl WasmTable<Engine> for Table {
             .get(ctx.as_context_mut().into_inner(), u64::from(index))
             .map(ref_from)
             .transpose()
-            .unwrap()
+            .expect("failed to convert type")
     }
 
     fn set(&self, mut ctx: impl AsContextMut<Engine>, index: u32, elem: Ref<Engine>) -> Result<()> {


### PR DESCRIPTION
Replaced many instances of `.unwrap()` with `.expect()` with meaningful error messages to improve error reporting and debugging, as suggested in #78.

Changes focus on the backend implementations where error context is most valuable.

Closes #78