### PR TITLE
Update Wasmi to `v2.0.0-beta.7`

### DIFF
--- a/backends/wasmi_runtime_layer/Cargo.toml
+++ b/backends/wasmi_runtime_layer/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = { workspace = true }
 ref-cast = { workspace = true }
 smallvec = { workspace = true }
 wasm_runtime_layer = { workspace = true }
-wasmi = { version = "=2.0.0-beta.5", default-features = false, features = ["validate"] }
+wasmi = { version = "=2.0.0-beta.7", default-features = false, features = ["validate", "auto-dispatch"] }
 
 [features]
 default = [ "std" ]


### PR DESCRIPTION
I enabled the new `auto-dispatch` feature as it will make the new Wasmi dispatch portable without losing performance where possible.

cc @juntyr 